### PR TITLE
2025 Dev branch testing and notes- 

### DIFF
--- a/Add-HuduAttachmentsViaAPI.ps1
+++ b/Add-HuduAttachmentsViaAPI.ps1
@@ -137,14 +137,16 @@ if ((get-host).version.major -ne 7) {
 
 # Get the Hudu API Module if not installed
 ## 2.4.5 is required for the New-HuduUpload function
-if ((Get-Module -ListAvailable -Name HuduAPI).version -ge '2.4.5') {
-    Import-Module HuduAPI
-} else {
-    Install-Module HuduAPI -MinimumVersion '2.4.5'
-    Import-Module HuduAPI
-}
+# if ((Get-Module -ListAvailable -Name HuduAPI).version -ge '2.4.5') {
+#     Import-Module HuduAPI
+# } else {
+#     Install-Module HuduAPI -MinimumVersion '2.4.5'
+#     Import-Module HuduAPI
+# }
+Import-Module "C:\Users\Administrator\Documents\GitHub\HuduAPI\HuduAPI\HuduAPI.psm1"
+
 # override this method, since it's retry method fails
-. .\Public\Invoke-HuduRequest.ps1
+# . .\Public\Invoke-HuduRequest.ps1
 
 #Login to Hudu
 New-HuduAPIKey $HuduAPIKey

--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -1250,6 +1250,22 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\AssetLayouts.json")) 
 
 ############################### Flexible Assets ###############################
 #Check for Assets Resume
+function Get-CastIfNumeric {
+    param([Parameter(Mandatory=$true)][object]$Value)
+
+    if ($Value -is [string]) {
+        $Value = $Value.Trim()
+        if ($Value -match '^\d+$') {
+            return [int]$Value
+        }
+        elseif ($Value -match '^\d+\.\d+$') {
+            return [double]$Value
+        }
+    }
+    return $Value
+}
+
+
 if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Assets.json")) {
     Write-Host "Loading Previous Asset Migration"
     $MatchedAssets = Get-Content "$MigrationLogs\Assets.json" -raw | Out-String | ConvertFrom-Json -depth 100
@@ -1449,7 +1465,8 @@ $ITGPasswordsRaw = Import-CSV -Path "$ITGLueExportPath\passwords.csv"
                                 }
                                 $null = $MatchedAssetPasswords.add($MigratedPassword)
                             } else {
-                                $null = $AssetFields.add("$($field.HuduParsedName)", ($_.value -replace '[^\x09\x0A\x0D\x20-\xD7FF\xE000-\xFFFD\x10000\x10FFFF]'))
+                                $coerced = Get-CastIfNumeric ($_.value -replace '[^\x09\x0A\x0D\x20-\xD7FF\xE000-\xFFFD\x10000\x10FFFF]')
+                                $null = $AssetFields.add("$($field.HuduParsedName)", $coerced)
                             }
                         }
                     }

--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -1266,6 +1266,7 @@ function Get-CastIfNumeric {
 }
 
 
+
 if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Assets.json")) {
     Write-Host "Loading Previous Asset Migration"
     $MatchedAssets = Get-Content "$MigrationLogs\Assets.json" -raw | Out-String | ConvertFrom-Json -depth 100

--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -2106,25 +2106,47 @@ Write-TimedMessage -Timeout 3 -Message "Snapshot Point: Article URLs Replaced. C
 # Assets
 $assetsUpdated = @()
 foreach ($assetFound in $UpdateAssets.HuduObject) {
-    $fieldsFound = $assetFound.fields | Where-Object {$_.value -like "*$ITGURL*"}
     $originalAsset = $assetFound
-    foreach ($field in $fieldsFound) {
-        $NewContent = Update-StringWithCaptureGroups -inputString $field.value -pattern $RichRegexPatternToMatchSansAssets -type "rich"
-        $NewContent = Update-StringWithCaptureGroups -inputString $NewContent -pattern $RichRegexPatternToMatchWithAssets -type "rich"
-        if ($NewContent) {
-            Write-Host "Replacing Asset $($assetFound.name) field $($field.caption) with replaced Content" -ForegroundColor 'Red'
-            ($assetFound.fields | Where-Object {$_.id -eq $field.id}).value = $NewContent
-            $replacedStatus = 'replaced'
+    $replacedStatus = 'clean'
+    $customFields = @()
+
+    foreach ($field in $assetFound.fields) {
+        # Convert the caption to snake_case to match API expectations for 2.37.1
+        $label = ($field.caption -replace '[^\w\s]', '') -replace '\s+', '_' | ForEach-Object { $_.ToLower() }
+
+        if ($label -in @('itglue_url', 'itglue_id', 'imported_from_itglue') -and $field.value -like "*$ITGURL*") {
+            $NewContent = Update-StringWithCaptureGroups -inputString $field.value -pattern $RichRegexPatternToMatchSansAssets -type "rich"
+            $NewContent = Update-StringWithCaptureGroups -inputString $NewContent -pattern $RichRegexPatternToMatchWithAssets -type "rich"
+
+            if ($NewContent -and $NewContent -ne $field.value) {
+                Write-Host "Replacing Asset $($assetFound.name) field $($field.caption) with updated content" -ForegroundColor 'Red'
+                $customFields += @{ $label = $NewContent }
+                $replacedStatus = 'replaced'
+            } else {
+                $customFields += @{ $label = $field.value }
+            }
+        } else {
+            # For other fields, preserve existing value (optional)
+            $customFields += @{ $label = $field.value }
         }
     }
-    if ($replacedStatus -ne 'replaced') {$replacedStatus = 'clean'}
-    else {
-        Write-Host "Updating Asset $($assetFound.name) with replaced field values" -ForegroundColor 'Green'
-        $AssetPost = Set-HuduAsset -asset_layout_id $assetFound.asset_layout_id -Name $assetFound.name -AssetId $assetFound.id -CompanyId $assetFound.company_id -Fields $assetFound.fields
-    }
-    $assetsUpdated = $assetsUpdated + @{"status" = $replacedStatus; "original_asset" = $originalAsset; "updated_asset" = $AssetPost.asset}
 
+    if ($replacedStatus -eq 'replaced') {
+        Write-Host "Updating Asset $($assetFound.name) with new custom_fields array" -ForegroundColor 'Green'
+        $AssetPost = Invoke-HuduRequest -Method PUT -Resource "api/v1/companies/$($assetFound.company_id)/assets/$($assetFound.id)" -Body @{
+            name              = $assetFound.name
+            asset_layout_id   = $assetFound.asset_layout_id
+            custom_fields     = $customFields
+        }
+    }
+
+    $assetsUpdated += @{
+        status         = $replacedStatus
+        original_asset = $originalAsset
+        updated_asset  = $AssetPost.asset
+    }
 }
+
 
 $assetsUpdated | ConvertTo-Json -depth 100 |Out-file "$MigrationLogs\ReplacedAssetsURL.json"
 Write-TimedMessage -Timeout 3 -Message  "Snapshot Point: Assets URLs Replaced. Continue?" -DefaultResponse "continue to Passwords Matching, please."

--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -109,13 +109,14 @@ if ((get-host).version.major -ne 7) {
 
 
 #Get the Hudu API Module if not installed
-if ((Get-Module -ListAvailable -Name HuduAPI).version -ge '2.4.4') {
-    Import-Module HuduAPI
-} else {
-    Install-Module HuduAPI -MinimumVersion 2.4.5 -Scope CurrentUser
-    Import-Module HuduAPI
-}
+# if ((Get-Module -ListAvailable -Name HuduAPI).version -ge '2.4.4') {
+#     Import-Module HuduAPI
+# } else {
+#     Install-Module HuduAPI -MinimumVersion 2.4.5 -Scope CurrentUser
+#     Import-Module HuduAPI
+# }
   
+Import-Module "C:\Users\Administrator\Documents\GitHub\HuduAPI\HuduAPI\HuduAPI.psm1"
 
 #Login to Hudu
 New-HuduAPIKey $HuduAPIKey
@@ -142,7 +143,7 @@ If (Get-Module -ListAvailable -Name "ITGlueAPIv2") {
 }
 
 # override this method, since it's retry method fails
-. $PSScriptRoot\Public\Invoke-HuduRequest.ps1
+# . $PSScriptRoot\Public\Invoke-HuduRequest.ps1
 
 
 #Settings IT-Glue logon information

--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -1250,21 +1250,21 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\AssetLayouts.json")) 
 
 ############################### Flexible Assets ###############################
 #Check for Assets Resume
-    function Get-CastIfNumeric {
-        param([Parameter(Mandatory=$true)][object]$Value)
+    # function Get-CastIfNumeric {
+    #     param([Parameter(Mandatory=$true)][object]$Value)
 
-        if ($Value -is [string]) {
-            $Value = $Value.Trim()
-            if ($Value -match '^\d+$') {
-                return [int]$Value
-            } elseif ($Value -match '^\d+\.0+$') {
-                return [int][double]$Value  # handles "2.0" => 2
-            } elseif ($Value -match '^\d+\.\d+$') {
-                return {[double]$Value} if ([double]$Value -le 2147483647) else {}
-            }
-        }
-        return $Value
-    }
+    #     if ($Value -is [string]) {
+    #         $Value = $Value.Trim()
+    #         if ($Value -match '^\d+$') {
+    #             return [int]$Value
+    #         } elseif ($Value -match '^\d+\.0+$') {
+    #             return [int][double]$Value  # handles "2.0" => 2
+    #         } elseif ($Value -match '^\d+\.\d+$') {
+    #             return {[double]$Value} if ([double]$Value -le 2147483647) else {}
+    #         }
+    #     }
+    #     return $Value
+    # }
 
 
 function Get-CastIfNumeric {

--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -47,6 +47,31 @@ $FontAwesomeUpgrade = Get-FontAwesomeMap
 
 ############################### End of Functions ###############################
 
+function Write-ITGErrorObjectToFile {
+    param (
+        [Parameter(Mandatory)]
+        [object]$ErrorObject,
+        [string]$Name
+    )
+    $stringOutput = $ErrorObject | Out-String
+    $jsonOutput = try {
+        $ErrorObject | ConvertTo-Json -Depth 96 -ErrorAction Stop
+    } catch {
+        "Failed to convert to JSON: $_"
+    }
+    $logContent = @"
+==== RAW STRING ====
+$stringOutput
+==== JSON FORMAT ====
+$jsonOutput
+"@
+    if ($null -ne $ITG_ERRORS_DIRECTORY) {
+        $filename = "$($Name -replace '\s+', '')_error_$(Get-Date -Format 'yyyyMMdd_HHmmss').log"
+        $fullPath = Join-Path $ITG_ERRORS_DIRECTORY $filename
+        Set-Content -Path $fullpath -Value $logContent -Encoding UTF8
+    }
+        Write-Host "$logContent" -ForegroundColor Yellow
+}
 
 ###################### Initial Setup and Confirmations ###############################
 Write-Host "#######################################################" -ForegroundColor Green

--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -469,7 +469,6 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Websites.json")) {
 
     $MatchedWebsites = foreach ($itgdomain in $ITGDomains ) {
         $HuduWebsite = $HuduWebsites | Where-Object { ($_.name -eq "https://$($itgdomain.attributes.name)" -and $_.company_name -eq $itgdomain.attributes."organization-name") }
-
         if ($HuduWebsite) {
             [PSCustomObject]@{
                 "Name"       = $itgdomain.attributes.name
@@ -516,11 +515,9 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Websites.json")) {
 				
 
                     Confirm-Import -ImportObjectName "$($unmatchedWebsite.Name)" -ImportObject $unmatchedWebsite -ImportSetting $ImportOption
-
                     Write-Host "Starting $($unmatchedWebsite.Name)"
 
                     $HuduNewWebsite = New-HuduWebsite -name "https://$($unmatchedWebsite.ITGObject.attributes.name)" -notes $unmatchedWebsite.ITGObject.attributes.notes -paused $DisableWebsiteMonitoring -companyid $company.HuduCompanyObject.ID -disabledns $DisableWebsiteMonitoring -disablessl $DisableWebsiteMonitoring -disablewhois $DisableWebsiteMonitoring
-
 
                     $unmatchedWebsite.matched = $true
                     $unmatchedWebsite.HuduID = $HuduNewWebsite.id

--- a/Initialize-Module.ps1
+++ b/Initialize-Module.ps1
@@ -19,9 +19,6 @@
 # Convert to a full blown module, prompts for interactive migration experience, save settings to an outside file for secure sharing
 # Add/enhance the migration areas to use the new API features of Hudu
 
-
-
-
 param(
     [Parameter(Mandatory=$true)]
     [ValidateSet("Full", "Lite")]

--- a/Public/Invoke-HuduRequest.ps1
+++ b/Public/Invoke-HuduRequest.ps1
@@ -101,7 +101,7 @@ function Invoke-HuduRequest {
         $Results = Invoke-RestMethod @RestMethod
     } catch {
         $errorMessage = $_.Exception.Message
-        Write-Error "$(($RestMethod | ConvertTo-Json -Depth 24).ToString()) => $errorMessage"
+        Write-Host "$(($RestMethod | ConvertTo-Json -Depth 24).ToString()) => $errorMessage" -ForegroundColor Yellow
 
         if ($errorMessage -like '*Retry later*' -or $errorMessage -like '*429*Too Many Requests*') {
             $now = Get-Date

--- a/environ.example
+++ b/environ.example
@@ -1,14 +1,23 @@
 
 $project_workdir="$PSScriptRoot"
+$env_name
+
 $debug_folder=$(join-path "$project_workdir" "debug")
+$errors_folder=$(join-path $debug_folder "errors")
+$global:GLOBAL_ERRORS_DIRECTORY="$errors_folder"
+$global:HAPI_ERRORS_DIRECTORY=$(join-path "$errors_folder" "huduapi")
+$global:ITG_ERRORS_DIRECTORY=$(join-path "$errors_folder" "itglue")
+
+
 $settings_folder=$(join-path "$project_workdir" "debug\settings")
 $logs_folder=$(join-path "$project_workdir" "debug\logs")
-$defaultSettingsPath=$(join-path "$settings_folder" "environ1.json")
+$defaultSettingsPath=$(join-path "$settings_folder" "$envname.json")
 
-if (!(Test-Path -Path "$debug_folder")) { New-Item "$debug_folder" -ItemType Directory }
-if (!(Test-Path -Path "$settings_folder")) { New-Item "$settings_folder" -ItemType Directory }
-if (!(Test-Path -Path "$logs_folder")) { New-Item "$logs_folder" -ItemType Directory }
 
+foreach ($folder in @($debug_folder, $errors_folder, $logs_folder, $settings_folder, $HAPI_ERRORS_DIRECTORY, $ITG_ERRORS_DIRECTORY)) {
+    if (!(Test-Path -Path "$folder")) { New-Item "$folder" -ItemType Directory }
+    Get-ChildItem -Path "$folder" -File -Recurse -Force | Remove-Item -Force
+}
 
 $InitType = "full"
 $settings = @{


### PR DESCRIPTION
Hey there, Mendy,
So, everything seems to work just fine with the inclusion of these preindexed-by-id hashtables. There were/are a few fixes that needed to be applied in order for everything to go smoothly on hudu version 2.37.1, however.


1. [fix for ratelimit on huduapi module](https://github.com/lwhitelock/HuduAPI/pull/65)
(*until this is published, we'll either have to override the invoke-hudurequest method or load module locally) Once published to psgallery, we can remove anything diffing with regards to huduapi module

2. [fix for not-allowed-fields](https://github.com/lwhitelock/ITGlue-Hudu-Migration/pull/30) this change is already present on source repo main branch. it simply removes name, created_at, and updated_at from one of the asset maps/splats early on. I just fast-forwarded dev-2025 from your main branch to include this.

3. numeral typecasting has been kind of tricky. It might be something we want to fix on Hudu side, but regardless there's a few things that seem to work fine to avoid these
-numerical string with/without single decimal is cast to double/int...
-limiting the value of signed int to max in rails...
-if double is even number (1.000) cast as int... 

  a few excerpts for item 3:
  first, it wasnt taking doubles (as json string) - eg "3.0"
  ```
  ...Point2Point T1\",\r\n        \"download_speed_(mbps)\": \"1.5\",\r\n        \"ip_address(es)\": \"<p>64.74.182.25</p>\"\r\n      }\r\n    ]\r\n  }\r\n}" } => Response status code does not indicate success: 422 (Unprocessable Content).
  {   "error": "Invalid custom fields",   "details": [
       | "Invalid format for \u0027Upload Speed (Mbps)\u0027. Must
       | be a valid number"   ] }'... Trying again in 5 seconds...
  ```
  
  then, raw doubles as an even number
  ```
  ...Point2Point T1\",\r\n        \"download_speed_(mbps)\": 3.0,\r\n        \"ip_address(es)\": \"<p>64.74.182.25</p>\"\r\n      }\r\n    ]\r\n  }\r\n}" } => Response status code does not indicate success: 422 (Unprocessable Content).
  {   "error": "Invalid custom fields",   "details": [
       | "Invalid format for \u0027Upload Speed (Mbps)\u0027. Must
       | be a valid number"   ] }'... Trying again in 5 seconds...
  ```
  
  for our ITGlue instance in specific, it was mainly specific to fields:
  
  seats
  download_speed_(mbps)
  upload_speed_(mbps)
  quantity

it looks a little junky right now, but once a few full, fresh runs complete in tests tonight, I can clean up first
