### PR TITLE
Chore/nullsafe passwordsplat

### DIFF
--- a/Public/Normalize-And-ConvertImage.ps1
+++ b/Public/Normalize-And-ConvertImage.ps1
@@ -1,0 +1,72 @@
+function Get-ImageType {
+    param (
+        [string]$FilePath
+    )
+    try {
+        $Magick = New-Object ImageMagick.MagickImage($FilePath)
+        return $Magick.Format.ToString().ToLower()
+    } catch {
+        return $null
+    }
+}
+function Normalize-And-ConvertImage {
+    param (
+        [string]$InputPath,
+        [int]$MaxLength = 64
+    )
+
+    $original = $InputPath
+
+    # If no extension, guess and copy with guessed extension
+    if ((Get-Item -Path $InputPath).Extension -eq '') {
+        $Magick = New-Object ImageMagick.MagickImage($InputPath)
+        $guessedExt = $Magick.Format.ToString().ToLower()
+        $InputPath += ".$guessedExt"
+        Copy-Item -Path $original -Destination $InputPath -Force
+    }
+
+    # Detect type
+    $type = Get-ImageType $InputPath
+    Write-Verbose "Detected image type: $type" -Verbose
+
+    $preserveExt = @('jpg', 'jpeg', 'png') -contains $type
+
+    # Only convert and change extension if not in safe list
+    if ($type -and -not $preserveExt) {
+        $Magick = New-Object ImageMagick.MagickImage($InputPath)
+        $convertedPath = [System.IO.Path]::ChangeExtension($InputPath, 'jpg')
+        $Magick.Format = [ImageMagick.MagickFormat]::Jpeg
+        $Magick.Write($convertedPath)
+        $InputPath = $convertedPath
+        $type = 'jpg'  # Important: Update type since we converted
+    }
+
+    # Normalize and shorten
+    $filename = [IO.Path]::GetFileName($InputPath)
+    $directory = [IO.Path]::GetDirectoryName($InputPath)
+    $normalized = Normalize-String -InputString $filename -PreserveExtension -PreserveWhitespace
+    $limited = Limit-FilenameLength -FullFilename $normalized -MaxLength $MaxLength -PreserveExtension
+
+    # Rebuild parts
+    $extension = [IO.Path]::GetExtension($limited)
+    $basename = [IO.Path]::GetFileNameWithoutExtension($limited)
+
+    if (-not $basename) { $basename = "file" }
+    if (-not $extension) { $extension = ".$type" }
+
+    if ($basename.Length -lt 5) {
+        $basename = $basename.PadRight(5, '_')
+    }
+
+    $finalFilename = "$basename$extension"
+    $finalPath = Join-Path -Path $directory -ChildPath $finalFilename
+
+    if ($InputPath -ne $finalPath) {
+        Copy-Item -Path $InputPath -Destination $finalPath -Force
+    }
+
+    return @{
+        FinalPath = $finalPath
+        Original  = $original
+    }
+}

--- a/Public/Normalize-String.ps1
+++ b/Public/Normalize-String.ps1
@@ -2,43 +2,30 @@ function Normalize-String {
     param (
         [Parameter(Mandatory = $true)]
         [string]$InputString,
-
-        [switch]$PreserveWhitespace
+        [switch]$PreserveWhitespace,
+        [switch]$PreserveExtension
     )
+    $extension = ""
+    $basename = $InputString
+    if ($PreserveExtension) {
+        $extension = [IO.Path]::GetExtension($InputString)
+        $basename = [IO.Path]::GetFileNameWithoutExtension($InputString)
+    }
 
     # Normalize Unicode (decompose accents), then remove non-ASCII
-    $normalized = $InputString.Normalize([Text.NormalizationForm]::FormD)
+    $normalized = $basename.Normalize([Text.NormalizationForm]::FormD)
     $chars = $normalized.ToCharArray() | Where-Object {
         ([Globalization.CharUnicodeInfo]::GetUnicodeCategory($_) -ne 'NonSpacingMark')
     }
-
     $ascii = -join $chars
-
     if ($PreserveWhitespace) {
-        # Keep A-Z, a-z, 0-9, space, dash, underscore
-        return ($ascii -replace '[^a-zA-Z0-9 _-]', '')
+        $ascii = $ascii -replace '[^a-zA-Z0-9 _-]', ''
     } else {
-        # Strict: Keep only alphanumeric
-        return ($ascii -replace '[^a-zA-Z0-9]', '')
+        $ascii = $ascii -replace '[^a-zA-Z0-9]', ''
     }
+    return "$ascii$extension"
 }
 
-function Limit-FilenameLength {
-    param (
-        [string]$FullFilename,
-        [int]$MaxLength = 100
-    )
-
-    $extension = [IO.Path]::GetExtension($FullFilename)
-    $basename = [IO.Path]::GetFileNameWithoutExtension($FullFilename)
-
-    $maxBaseLength = $MaxLength - $extension.Length
-    if ($basename.Length -gt $maxBaseLength) {
-        $basename = $basename.Substring(0, $maxBaseLength)
-    }
-
-    return "$basename$extension"
-}
 
 function Limit-FilenameLength {
     param (
@@ -66,3 +53,4 @@ function Limit-FilenameLength {
         }
     }
 }
+


### PR DESCRIPTION
Performing test for null/empty password in @passwordsplat

![image](https://github.com/user-attachments/assets/307171c4-2b19-484f-89f5-d8ab76a5574a)

should work fine for the 2-3 empty passwords we do have. Simply add them to manualactions
![image](https://github.com/user-attachments/assets/3e31eed4-52c2-459b-8ae3-f150b2ce20f0)
