### PR TITLE
Chore/nullsafe pass splat2

### DIFF
--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -2075,7 +2075,7 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Passwords.json")) {
                                 password          = ""
                                 url               = $unmatchedPassword.ITGObject.attributes.url
                                 username          = $unmatchedPassword.ITGObject.attributes.username
-                                otpsecret         = $validated_otp
+                                otpsecret         = "removed for security purposes"
                                 problem           = "password was null or empty"
                             })
                             $unmatchedPassword.matched = $false

--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -2050,6 +2050,7 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Passwords.json")) {
                         if (-not ($isValidBase32 -and $lengthOK)) {
                             Write-Warning "Invalid OTP secret for $($unmatchedPassword.ITGObject.attributes.name): $($unmatchedPassword.ITGObject.attributes.otp_secret)... valid base32? $isValidBase32 length ok? $lengthOK (min / max is 16 / 80 chars)"
                         }
+                        $passwordRaw = "$($unmatchedPassword.ITGObject.attributes.password)"
                         $PasswordSplat = @{
                             name              = "$($unmatchedPassword.ITGObject.attributes.name)"
                             company_id        = $company.HuduCompanyObject.ID
@@ -2063,18 +2064,31 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Passwords.json")) {
                             otpsecret         = $validated_otp
 
                         }
-
-                        $HuduNewPassword = (New-HuduPassword @PasswordSplat).asset_password
-
-                        $unmatchedPassword.matched = $true
-                        $unmatchedPassword.HuduID = $HuduNewPassword.id
-                        $unmatchedPassword."HuduObject" = $HuduNewPassword
-                        $unmatchedPassword.Imported = "Created-By-Script"
-
-                        $ImportsMigrated = $ImportsMigrated + 1
-
-                        Write-host "$($HuduNewPassword.Name) Has been created in Hudu"
-
+                        if ([string]::IsNullOrWhiteSpace($passwordRaw) -or $passwordRaw.Length -lt 1) {                            
+                            $manualActions.add([PSCustomObject]@{
+                                name              = "$($unmatchedPassword.ITGObject.attributes.name)"
+                                company_id        = $company.HuduCompanyObject.ID
+                                description       = $unmatchedPassword.ITGObject.attributes.notes
+                                passwordable_type = $PasswordableType
+                                passwordable_id   = $ParentItemID
+                                in_portal         = $false
+                                password          = ""
+                                url               = $unmatchedPassword.ITGObject.attributes.url
+                                username          = $unmatchedPassword.ITGObject.attributes.username
+                                otpsecret         = $validated_otp
+                                problem           = "password was null or empty"
+                            })
+                            $unmatchedPassword.matched = $false
+                            Write-host "$($HuduNewPassword.Name) Has been skipped and added to manual actions due to being empty"                            
+                        } else {
+                            $HuduNewPassword = (New-HuduPassword @PasswordSplat).asset_password 
+                            $unmatchedPassword.matched = $true
+                            $unmatchedPassword.HuduID = $HuduNewPassword.id
+                            $unmatchedPassword."HuduObject" = $HuduNewPassword
+                            $unmatchedPassword.Imported = "Created-By-Script"
+                            $ImportsMigrated = $ImportsMigrated + 1
+                            Write-host "$($HuduNewPassword.Name) Has been created in Hudu"
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This includes both the OTP validation and password length validation within @passwordsplat.
While most passwords aren't empty and most OTPs are between 16-80 chars, we've seen a few come up in our (very old) itglue instance. Although unexpected, it's better to handle such cases if at all possible!

since both concerns/issues involve the same splat in the same spot, these were both included. 

![image](https://github.com/user-attachments/assets/6e0fcf14-cc17-43d9-8253-1585e0bacc51)

![image](https://github.com/user-attachments/assets/dc096cd7-0b45-4b26-9c46-c3d275bdc9a7)
