### PR TITLE
remove-postrun tasks from environ example

### DIFF
--- a/environ.example
+++ b/environ.example
@@ -81,7 +81,3 @@ $ScopedMigration            = 1
 # )
 
 . .\ITGlue-Hudu-Migration.ps1
-foreach ($layout in Get-HuduAssetLayouts) {write-host "setting $($(Set-HuduAssetLayout -id $layout.id -Active $true).asset_layout.name) as active" }
-. .\Get-MissingRelations.ps1
-. .\Add-HuduAttachmentsViaAPI.ps1
-$ConfigurationRelationsToCreate + $AssetRelationsToCreate | ForEach-Object {try {New-HuduRelation -FromableType  $_.FromableType -FromableID    $_.FromableID -ToableType    $_.ToableType -ToableID      $_.ToableID} catch {Write-Host "Skipped or errored: $_" -ForegroundColor Yellow}}


### PR DESCRIPTION
postrun tasks are now optionally executed in-context of main script, so users who hadn't invoked with dotsourcing will not be left-out afterwards

as such, we can safely omit these from environment example
