### PR TITLE
Feat/date safety

### DIFF
--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -1421,8 +1421,17 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Assets.json")) {
                 if ($field) {
                     $supported = $true
 
-                    if ($field.FieldType -eq "Tag") {
-				
+                    if ($field.FieldType -eq "Date") {
+                        $ReturnData = $ITGValues.values ?? $ITGValues
+                        if (-not [bool]$(Test-DateAfter -DateString "$ReturnData" -Cutoff '1000-01-01')) {
+                            if ($true -eq $field.HuduLayoutField.required){
+                                $ReturnData = $(get-date).ToUniversalTime().ToString("yyyy-MM-dd")
+                            } else {
+                                continue
+                            }
+                        }
+                        $null = $AssetFields.add("$($field.HuduParsedName)", ("$ReturnData"))
+                    } elseif ($field.FieldType -eq "Tag") {
                         switch ($field.FieldSubType) {
                             "AccountsUsers" { Write-Host "Tags to Account Users are not supported $($field.FieldName) in $($UpdateAsset.Name) will need to be manually migrated, Sorry!"; $supported = $false }
                             "Checklists" { Write-Host "Tags to Checklists are not supported $($field.FieldName) in $($UpdateAsset.Name) will need to be manually migrated, Sorry!"; $supported = $false }
@@ -1433,8 +1442,6 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Assets.json")) {
                                 }
                                 $ReturnData = $ContactsLinked | convertto-json -compress -AsArray | Out-String
                                 $null = $AssetFields.add("$($field.HuduParsedName)", ("$ReturnData"))
-											
-											
                             }
                             "Configurations" {
                                 $ConfigsLinked = foreach ($IDMatch in $ITGValues.values) {

--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -1421,11 +1421,12 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Assets.json")) {
                 if ($field) {
                     $supported = $true
 
-                    if ($field.FieldType -eq "Date") {
-                        $ReturnData = $ITGValues.values ?? $ITGValues
-                        if (-not [bool]$(Test-DateAfter -DateString "$ReturnData" -Cutoff '1000-01-01')) {
-                            if ($true -eq $field.HuduLayoutField.required){
-                                $ReturnData = $(get-date).ToUniversalTime().ToString("yyyy-MM-dd")
+                    if ($field.FieldType -ilike "*Date*") {
+                        $raw = ($ITGValues.values ?? $ITGValues) -as [string]
+                        $ReturnData = Get-CoercedDate -InputDate $raw -Cutoff '1000-01-01' -OutputFormat 'MM/DD/YYYY'
+                        if (-not $ReturnData) {
+                            if ($field.HuduLayoutField.required) {
+                                $ReturnData = (Get-Date).ToString('MM/dd/yyyy', [CultureInfo]::InvariantCulture)
                             } else {
                                 continue
                             }

--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -1421,7 +1421,7 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Assets.json")) {
                 if ($field) {
                     $supported = $true
 
-                    if ($field.FieldType -ilike "*Date*") {
+                    if ($field.FieldType -eq "Date") {
                         $raw = ($ITGValues.values ?? $ITGValues) -as [string]
                         $ReturnData = Get-CoercedDate -InputDate $raw -Cutoff '1000-01-01' -OutputFormat 'MM/DD/YYYY'
                         if (-not $ReturnData) {

--- a/Public/Get-CastIfNumeric.ps1
+++ b/Public/Get-CastIfNumeric.ps1
@@ -33,3 +33,34 @@ function Test-DateAfter {
     if (-not $ok) { return $false }   # invalid format → fail
     return ($dt -ge $Cutoff)
 }
+
+function Get-CoercedDate {
+    param(
+        [Parameter(Mandatory)][string]$InputDate,
+        [datetime]$Cutoff = [datetime]'1000-01-01',
+        [ValidateSet('DD.MM.YYYY','YYYY.MM.DD','MM/DD/YYYY')]
+        [string]$OutputFormat = 'MM/DD/YYYY'
+    )
+
+    $Inv    = [System.Globalization.CultureInfo]::InvariantCulture
+    $Styles = [System.Globalization.DateTimeStyles]::AllowWhiteSpaces -bor `
+              [System.Globalization.DateTimeStyles]::AssumeLocal
+    $Accepted = @(
+        "MM'/'dd'/'yyyy HH':'mm':'ss",
+        "MM'/'dd'/'yyyy hh':'mm':'ss tt"
+    )
+
+    $dt = $null
+    if (-not [datetime]::TryParseExact($InputDate, $Accepted, $Inv, $Styles, [ref]$dt)) {
+        return $null
+    }
+
+    # cutoff check using yyyy-MM-dd
+    if ($dt -lt $Cutoff) { return $null }
+
+    switch ($OutputFormat) {
+        'DD.MM.YYYY' { $dt.ToString('dd.MM.yyyy', $Inv) }
+        'YYYY.MM.DD' { $dt.ToString('yyyy.MM.dd', $Inv) }
+        'MM/DD/YYYY' { $dt.ToString('MM/dd/yyyy', $Inv) }
+    }
+}

--- a/Public/Get-CastIfNumeric.ps1
+++ b/Public/Get-CastIfNumeric.ps1
@@ -17,3 +17,19 @@ function Get-CastIfNumeric {
     }
     return $Value
 }
+function Test-DateAfter {
+    param(
+        [Parameter(Mandatory)][string]$DateString,
+        [datetime]$Cutoff = [datetime]'1000-01-01'
+    )
+    $dt = $null
+    $ok = [datetime]::TryParseExact(
+        $DateString,
+        'yyyy-MM-dd',
+        [System.Globalization.CultureInfo]::InvariantCulture,
+        [System.Globalization.DateTimeStyles]::AssumeUniversal,
+        [ref]$dt
+    )
+    if (-not $ok) { return $false }   # invalid format → fail
+    return ($dt -ge $Cutoff)
+}

--- a/Public/Get-CastIfNumeric.ps1
+++ b/Public/Get-CastIfNumeric.ps1
@@ -45,17 +45,14 @@ function Get-CoercedDate {
     $Inv    = [System.Globalization.CultureInfo]::InvariantCulture
     $Styles = [System.Globalization.DateTimeStyles]::AllowWhiteSpaces -bor `
               [System.Globalization.DateTimeStyles]::AssumeLocal
-    $Accepted = @(
-        "MM'/'dd'/'yyyy HH':'mm':'ss",
-        "MM'/'dd'/'yyyy hh':'mm':'ss tt"
-    )
+    $Accepted = [string[]]@('MM/dd/yyyy HH:mm:ss','MM/dd/yyyy hh:mm:ss tt')
 
     $dt = $null
-    if (-not [datetime]::TryParseExact($InputDate, $Accepted, $Inv, $Styles, [ref]$dt)) {
-        return $null
-    }
-
-    # cutoff check using yyyy-MM-dd
+    try {
+        if (-not [datetime]::TryParseExact($InputDate, $Accepted, $Inv, $Styles, [ref]$dt)) {
+            return $null
+        }
+    } catch { return $null }
     if ($dt -lt $Cutoff) { return $null }
 
     switch ($OutputFormat) {


### PR DESCRIPTION
date coercion and safety, tryparse date into standard format for hudu, since liongaurd, datto integrations have the same field.fieldtype, but different date format. Further, date must be year 1000 or newer. If field is required, defaults to today, otherwise set to null.