### PR TITLE
adding url decode for procedure/task names. further, allowing for emp…

### DIFF
--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -278,6 +278,7 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Companies.json")) {
 	
         if (($importCOption -eq "A") -or ($importCOption -eq "S") ) {		
             foreach ($unmatchedcompany in ($MatchedCompanies | Where-Object { $_.Matched -eq $false })) {
+
                 $unmatchedcompany.ITGCompanyObject.attributes.'quick-notes' = ($ITGCompaniesFromCSV | Where-Object {$_.id -eq $unmatchedcompany.ITGID}).quick_notes
                 $unmatchedcompany.ITGCompanyObject.attributes.alert = ($ITGCompaniesFromCSV | Where-Object {$_.id -eq $unmatchedcompany.ITGID}).alert
                 Confirm-Import -ImportObjectName $($unmatchedcompany.CompanyName) -ImportObject $unmatchedcompany -ImportSetting $importCOption
@@ -1263,6 +1264,7 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\AssetLayouts.json")) 
             } else {
                 $NewLayout = New-HuduAssetLayout -name "$($FlexibleLayoutPrefix)$($UnmatchedLayout.ITGObject.attributes.name)-Assets" -icon "fas fa-$NewIcon" -color "#6136ff" -icon_color "#ffffff" -include_passwords $true -include_photos $true -include_comments $true -include_files $true -fields $TempLayoutFields 
             }
+
             $MatchedNewLayout = Get-HuduAssetLayouts -layoutid $NewLayout.asset_layout.id
 
             $UnmatchedLayout.HuduObject = $MatchedNewLayout
@@ -2137,32 +2139,38 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Passwords.json")) {
 
                         }
                         if ([string]::IsNullOrWhiteSpace($unmatchedPassword.ITGObject.attributes.password) -or $unmatchedPassword.ITGObject.attributes.password.Length -lt 1) {
-                            $manualActions.add([PSCustomObject]@{
-                                name              = "$($unmatchedPassword.ITGObject.attributes.name)"
-                                company_id        = $company.HuduCompanyObject.ID
-                                description       = $unmatchedPassword.ITGObject.attributes.notes
-                                passwordable_type = $PasswordableType
-                                passwordable_id   = $ParentItemID
-                                in_portal         = $false
-                                password          = ""
-                                Type              = "Password"
-				                Hudu_URL      	  = $unmatchedPassword.HuduObject.url
-                                ITG_URL           = if ($url = $unmatchedPassword.ITGObject.attributes.url) {$url} Else {$unmatchedPassword.ITGObject.attributes.'resource-url'}
-                                username          = $unmatchedPassword.ITGObject.attributes.username
-                                otpsecret         = "removed for security purposes"
-                                problem           = "password was null or empty"
-                            })
-                            $unmatchedPassword.matched = $false
-                            Write-Warning "$($HuduNewPassword.Name) Has been skipped and added to manual actions due to being empty"                            
-                        } else {
-                            $HuduNewPassword = (New-HuduPassword @PasswordSplat).asset_password 
-                            $unmatchedPassword.matched = $true
-                            $unmatchedPassword.HuduID = $HuduNewPassword.id
-                            $unmatchedPassword."HuduObject" = $HuduNewPassword
-                            $unmatchedPassword.Imported = "Created-By-Script"
-                            $ImportsMigrated = $ImportsMigrated + 1
-                            Write-host "$($HuduNewPassword.Name) Has been created in Hudu"
+                            if ($true -eq $($AllowEmptyPasswords ?? $false)) {
+                                write-host "Password value is empty for $($unmatchedPassword.ITGObject.attributes.name), assuming it is vaulted. setting blank password with AES-256-GCM encryption to preserve the record and metadata for replacing later." -ForegroundColor DarkCyan
+                                $PasswordSplat.password = "AES-256-GCM"
+                            } else {
+                                $manualActions.add([PSCustomObject]@{
+                                    name              = "$($unmatchedPassword.ITGObject.attributes.name)"
+                                    company_id        = $company.HuduCompanyObject.ID
+                                    description       = $unmatchedPassword.ITGObject.attributes.notes
+                                    passwordable_type = $PasswordableType
+                                    passwordable_id   = $ParentItemID
+                                    in_portal         = $false
+                                    password          = ""
+                                    Type              = "Password"
+                                    Hudu_URL      	  = $unmatchedPassword.HuduObject.url
+                                    ITG_URL           = if ($url = $unmatchedPassword.ITGObject.attributes.url) {$url} Else {$unmatchedPassword.ITGObject.attributes.'resource-url'}
+                                    username          = $unmatchedPassword.ITGObject.attributes.username
+                                    otpsecret         = "removed for security purposes"
+                                    problem           = "password was null or empty"
+                                })
+                                $unmatchedPassword.matched = $false
+                                Write-Warning "$($HuduNewPassword.Name) Has been skipped and added to manual actions due to being empty"
+                                continue
+                            }
                         }
+                        $HuduNewPassword = (New-HuduPassword @PasswordSplat).asset_password 
+                        $unmatchedPassword.matched = $true
+                        $unmatchedPassword.HuduID = $HuduNewPassword.id
+                        $unmatchedPassword."HuduObject" = $HuduNewPassword
+                        $unmatchedPassword.Imported = "Created-By-Script"
+                        $ImportsMigrated = $ImportsMigrated + 1
+                        Write-host "$($HuduNewPassword.Name) Has been created in Hudu"
+                        
                     }
                 }
             }

--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -2140,8 +2140,8 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Passwords.json")) {
                         }
                         if ([string]::IsNullOrWhiteSpace($unmatchedPassword.ITGObject.attributes.password) -or $unmatchedPassword.ITGObject.attributes.password.Length -lt 1) {
                             if ($true -eq $($AllowEmptyPasswords ?? $false)) {
-                                write-host "Password value is empty for $($unmatchedPassword.ITGObject.attributes.name), assuming it is vaulted. setting blank password with AES-256-GCM encryption to preserve the record and metadata for replacing later." -ForegroundColor DarkCyan
-                                $PasswordSplat.password = "AES-256-GCM"
+                                write-host "Password value is empty for $($unmatchedPassword.ITGObject.attributes.name), assuming it is vaulted. setting blank password with A256GCM encryption to preserve the record and metadata for replacing later." -ForegroundColor DarkCyan
+                                $PasswordSplat.password = "A256GCM.WAS-BLANK-REPLACE-WITH-REAL-PASSWORD"
                             } else {
                                 $manualActions.add([PSCustomObject]@{
                                     name              = "$($unmatchedPassword.ITGObject.attributes.name)"

--- a/Public/Process-Checklists.ps1
+++ b/Public/Process-Checklists.ps1
@@ -74,7 +74,7 @@ foreach ($checklist in $ITGLueChecklists) {
 
     $HuduProcedureTasks = @()
     $procedureRequest = @{
-        Name = ($checklist.attributes.name ?? 'Unnamed Procedure') 
+        Name = [System.Net.WebUtility]::UrlDecode("$($checklist.attributes.name ?? 'Unnamed Procedure')")
         CompanyTemplate = $checklist.IsTemplate ?? $false
         Description =  $($($checklist.attributes.description ?? "No description found for procedure.") + "`n" + 
             "Imported from ITGlue. <a href='$($checklist.attributes.'resource-url')'>itglue checklist url</a>")
@@ -112,7 +112,7 @@ foreach ($checklist in $ITGLueChecklists) {
 
             $NewTaskRequest = @{
                 ProcedureId = $newProcedure.id
-                Name        = ($task.attributes.name ?? ("Task #$($task.attributes.order)" ?? "Unnamed Task"))
+                Name        = [System.Net.WebUtility]::UrlDecode("$($task.attributes.name ?? ("Task #$($task.attributes.order)" ?? "Unnamed Task"))")
                 Description = ($task.attributes.description ?? "Imported from ITglue with no description")
             }
 

--- a/environ.example
+++ b/environ.example
@@ -100,6 +100,8 @@ $FolderNamingMode = "Name Based on Full Path with Delimiter" # how to name the p
                     # "Name Based on Root-Level-Directory"
                     # "Name Based on Current/Leaf-Level Directory"
 
+$AllowEmptyPasswords = $true # set this to true if you have company passwords vaulted.
+
 # pre-designated array/list of prescoped/preselected companies for scoped migration (for faster testing, ignore this if you want scoped migration, you'll select your own set)
 # prescoped Companies
 # $Prescoped = @(


### PR DESCRIPTION
environment option - allow for empty password in case of vaulting - i've had to manually work around this the last several migrations and I think it better to allow for user to more easily take this path.

url-decode names for procedures/tasks

