### PR TITLE
Feat/attachment url replace

### DIFF
--- a/Add-HuduAttachmentsViaAPI.ps1
+++ b/Add-HuduAttachmentsViaAPI.ps1
@@ -26,6 +26,7 @@ if (-not ($FirstTimeLoad -eq 1)) {
 
 # Attachments Path
 $AttachmentsPath = (Join-Path -Path $ITGLueExportPath -ChildPath "attachments")
+$AttachmentUrlMap = $AttachmentUrlMap ?? @{}
 
 ###################### Initial Setup and Confirmations ###############################
 Write-Host "#######################################################" -ForegroundColor Yellow
@@ -54,6 +55,73 @@ Write-Host "# https://github.com/lwhitelock/ITGlue-Hudu-Migration #" -Foreground
 Write-Host "#######################################################" -ForegroundColor Yellow
 
 ################### Supporting Functions ###############################
+
+function Resolve-HuduUploadUrl {
+param(
+    $Upload
+)
+    $UploadObject = $Upload.upload ?? $Upload
+    $UploadUrl = $UploadObject.url ?? $UploadObject.file_url ?? $UploadObject.download_url
+
+    if ([string]::IsNullOrWhiteSpace($UploadUrl)) { return $null }
+    if ($UploadUrl -match '^https?://') { return [string]$UploadUrl }
+    if ([string]::IsNullOrWhiteSpace($HuduBaseDomain)) { return [string]$UploadUrl }
+
+    return "$($HuduBaseDomain.TrimEnd('/'))/$($UploadUrl.TrimStart('/'))"
+}
+
+function Add-AttachmentUrlMapEntry {
+param(
+    [string]$OriginalUrl,
+    [string]$HuduUrl
+)
+    if ([string]::IsNullOrWhiteSpace($OriginalUrl) -or [string]::IsNullOrWhiteSpace($HuduUrl)) { return }
+
+    $script:AttachmentUrlMap[$OriginalUrl] = $HuduUrl
+}
+
+function Get-OriginalAttachmentUrl {
+param(
+    [System.IO.FileInfo]$FoundFile,
+    $FoundAsset
+)
+    $AttachmentsRoot = (Resolve-Path $AttachmentsPath).Path.TrimEnd([IO.Path]::DirectorySeparatorChar, [IO.Path]::AltDirectorySeparatorChar)
+    $RelativePath = $FoundFile.FullName.Substring($AttachmentsRoot.Length).TrimStart([char[]]@('\', '/'))
+    $PathParts = @($RelativePath -split '[\\/]')
+    if ($PathParts.Count -lt 3) { return $null }
+    if ([string]::IsNullOrWhiteSpace($ITGURL)) { return $null }
+
+    $AttachmentType = $PathParts[0]
+    $ITGID = $PathParts[1]
+    $ITGEntityType = switch ($AttachmentType) {
+        'documents' { 'docs' }
+        'passwords' { 'passwords' }
+        'configurations' { 'configurations' }
+        default { 'assets' }
+    }
+
+    $CompanyId = $FoundAsset.Company.ITGID ??
+        $FoundAsset.Company.id ??
+        $FoundAsset.ITGObject.attributes.'organization-id' ??
+        $FoundAsset.ITGObject.attributes.organization_id ??
+        $FoundAsset.ITGObject.relationships.organization.data.id
+
+    $FileUrlSegment = if ($FoundFile.Name -match '^(?<FileId>\d{1,20})[-_\s]') {
+        $Matches.FileId
+    } else {
+        [Uri]::EscapeDataString($FoundFile.Name)
+    }
+
+    if ($CompanyId) {
+        return "$($ITGURL.TrimEnd('/'))/$CompanyId/$ITGEntityType/$ITGID/files/$FileUrlSegment"
+    }
+
+    return "$($ITGURL.TrimEnd('/'))/$ITGEntityType/$ITGID/files/$FileUrlSegment"
+}
+
+function Save-AttachmentUrlMap {
+    $script:AttachmentUrlMap | ConvertTo-Json -Depth 10 | Out-File "$MigrationLogs\AttachmentUrlMap.json"
+}
 
 # Function for looping over found assets and attachments. Requires PSQL Connection
 function Add-HuduAttachment {
@@ -86,8 +154,12 @@ param(
                 Write-Host "Pushing $($FoundFile.name) to Hudu $($UploadType) $($FoundAsset.name) - $($FoundAsset.HuduID)" -ForegroundColor Blue
                 try {
                     $HuduUpload = New-HuduUpload -FilePath $FoundFile.fullname -uploadable_id $FoundAsset.HuduID -uploadable_type $UploadType
+                    $FullHuduUploadUrl = Resolve-HuduUploadUrl -Upload $HuduUpload
+                    $OriginalAttachmentUrl = Get-OriginalAttachmentUrl -FoundFile $FoundFile -FoundAsset $FoundAsset
+                    Add-AttachmentUrlMapEntry -OriginalUrl $OriginalAttachmentUrl -HuduUrl $FullHuduUploadUrl
                     [PSCustomObject]@{
-                        URL  = $HuduUpload.url
+                        URL  = $FullHuduUploadUrl
+                        OriginalAttachmentUrl = $OriginalAttachmentUrl
                         Uploadable_ID = $FoundAsset.HuduID
                         Uploadable_Type = $UploadType
                         FilePath  = $FoundFile.fullname
@@ -109,7 +181,7 @@ param(
     
     $SuffixSegment = if ([string]::IsNullOrWhiteSpace($FileSuffix)) { "" } else { "-$FileSuffix" }
     $Results |ConvertTo-Json -Compress -Depth 10 |Out-File "$($MigrationLogs)\$($UploadType)$SuffixSegment-attachments-upload.json"
-
+    return $results
 }
 
 # Used for Creating the CSV Mapping for FA Custom Upload fields
@@ -216,11 +288,20 @@ if ($true -eq $UploadFieldsArePresent){
     Write-Host "One or more Upload fields were present on the assets or we couldnt determine their presence. These will be uploaded now." -ForegroundColor Yellow
     . "$($(get-childitem -path "." -Recurse -file "Add-UploadFieldAttachments.ps1" | Select-Object -first 1).fullname)"
 
+    if ($MatchedUploadFields) {
+        foreach ($UploadField in $MatchedUploadFields.Values) {
+            Add-AttachmentUrlMapEntry -OriginalUrl $UploadField.ITGFileUrl -HuduUrl (Resolve-HuduUploadUrl -Upload $UploadField.Upload)
+        }
+    }
 }
 
 
 $CSVMapPath = "$MigrationLogs\AttachmentFields-CSVMap.json"
-if (-not (Test-Path $CSVMapPath)) {write-host "no optional CSV map found at $CSVMapPath. Attachments complete!"; exit}
+if (-not (Test-Path $CSVMapPath)) {
+    Save-AttachmentUrlMap
+    write-host "no optional CSV map found at $CSVMapPath. Attachments complete!"
+    exit
+}
 
 if (!($CSVMapping = Get-Content $CSVMapPath|ConvertFrom-Json -Depth 10)) {
     $CSVMapping = Build-CSVMapping
@@ -242,6 +323,9 @@ if ($CSVMapping) {
                     $HuduAssetName = $ITGlueAssets |Where-Object {$_.itgid -eq $record.id}  |Select-Object -ExpandProperty Name
                     Write-Host "Uploading $($FileToUpload.fullname) to Hudu Asset $($HuduAssetName) - $($HuduAssetID)" -ForegroundColor Blue
                     $HuduUpload = New-HuduUpload -FilePath $FileToUpload.fullname -uploadable_id $HuduAssetID -uploadable_type 'Asset'
+                    if ($fr -match '^https?://') {
+                        Add-AttachmentUrlMapEntry -OriginalUrl $fr -HuduUrl (Resolve-HuduUploadUrl -Upload $HuduUpload)
+                    }
 
                 }
             }
@@ -261,5 +345,6 @@ if ($CSVMapping) {
         }  
     }
 }
+Save-AttachmentUrlMap
 Write-Host "All attachments have been processed."
     

--- a/Add-HuduAttachmentsViaAPI.ps1
+++ b/Add-HuduAttachmentsViaAPI.ps1
@@ -27,6 +27,7 @@ if (-not ($FirstTimeLoad -eq 1)) {
 # Attachments Path
 $AttachmentsPath = (Join-Path -Path $ITGLueExportPath -ChildPath "attachments")
 $AttachmentUrlMap = $AttachmentUrlMap ?? @{}
+$ITGlueAttachmentCache = @{}
 
 ###################### Initial Setup and Confirmations ###############################
 Write-Host "#######################################################" -ForegroundColor Yellow
@@ -72,24 +73,24 @@ param(
 
 function Add-AttachmentUrlMapEntry {
 param(
-    [string]$OriginalUrl,
+    [string[]]$OriginalUrl,
     [string]$HuduUrl
 )
-    if ([string]::IsNullOrWhiteSpace($OriginalUrl) -or [string]::IsNullOrWhiteSpace($HuduUrl)) { return }
+    if (-not $OriginalUrl -or [string]::IsNullOrWhiteSpace($HuduUrl)) { return }
 
-    $script:AttachmentUrlMap[$OriginalUrl] = $HuduUrl
+    foreach ($Url in @($OriginalUrl | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)) {
+        $script:AttachmentUrlMap[$Url] = $HuduUrl
+    }
 }
 
-function Get-OriginalAttachmentUrl {
+function Get-AttachmentPathInfo {
 param(
-    [System.IO.FileInfo]$FoundFile,
-    $FoundAsset
+    [System.IO.FileInfo]$FoundFile
 )
     $AttachmentsRoot = (Resolve-Path $AttachmentsPath).Path.TrimEnd([IO.Path]::DirectorySeparatorChar, [IO.Path]::AltDirectorySeparatorChar)
     $RelativePath = $FoundFile.FullName.Substring($AttachmentsRoot.Length).TrimStart([char[]]@('\', '/'))
     $PathParts = @($RelativePath -split '[\\/]')
     if ($PathParts.Count -lt 3) { return $null }
-    if ([string]::IsNullOrWhiteSpace($ITGURL)) { return $null }
 
     $AttachmentType = $PathParts[0]
     $ITGID = $PathParts[1]
@@ -99,6 +100,22 @@ param(
         'configurations' { 'configurations' }
         default { 'assets' }
     }
+
+    [pscustomobject]@{
+        AttachmentType = $AttachmentType
+        ITGID          = $ITGID
+        ITGEntityType  = $ITGEntityType
+        RelativePath   = $RelativePath
+    }
+}
+
+function Get-OriginalAttachmentUrl {
+param(
+    [System.IO.FileInfo]$FoundFile,
+    $FoundAsset
+)
+    $PathInfo = Get-AttachmentPathInfo -FoundFile $FoundFile
+    if (-not $PathInfo -or [string]::IsNullOrWhiteSpace($ITGURL)) { return $null }
 
     $CompanyId = $FoundAsset.Company.ITGID ??
         $FoundAsset.Company.id ??
@@ -113,10 +130,145 @@ param(
     }
 
     if ($CompanyId) {
-        return "$($ITGURL.TrimEnd('/'))/$CompanyId/$ITGEntityType/$ITGID/files/$FileUrlSegment"
+        return "$($ITGURL.TrimEnd('/'))/$CompanyId/$($PathInfo.ITGEntityType)/$($PathInfo.ITGID)/files/$FileUrlSegment"
     }
 
-    return "$($ITGURL.TrimEnd('/'))/$ITGEntityType/$ITGID/files/$FileUrlSegment"
+    return "$($ITGURL.TrimEnd('/'))/$($PathInfo.ITGEntityType)/$($PathInfo.ITGID)/files/$FileUrlSegment"
+}
+
+function Get-ITGlueAttachmentResourceType {
+param(
+    [string]$AttachmentType,
+    [string]$UploadType
+)
+    switch ($AttachmentType) {
+        'documents' { 'documents' }
+        'configurations' { 'configurations' }
+        'contacts' { 'contacts' }
+        'locations' { 'locations' }
+        'passwords' { 'passwords' }
+        'websites' { 'domains' }
+        default {
+            if ($UploadType -eq 'AssetPassword') { 'passwords' }
+            elseif ($UploadType -eq 'Website') { 'domains' }
+            else { 'flexible_assets' }
+        }
+    }
+}
+
+function Normalize-ITGlueAttachmentFilename {
+param(
+    [string]$Name
+)
+    if ([string]::IsNullOrWhiteSpace($Name)) { return '' }
+
+    $Text = [IO.Path]::GetFileName($Name).Normalize([Text.NormalizationForm]::FormD)
+    $Chars = $Text.ToCharArray() | Where-Object {
+        [Globalization.CharUnicodeInfo]::GetUnicodeCategory($_) -ne [Globalization.UnicodeCategory]::NonSpacingMark
+    }
+
+    $Text = (-join $Chars).ToLowerInvariant()
+    $Text = $Text -replace '&', ' and '
+    $Text = $Text -replace '[^a-z0-9.]+', ' '
+    $Text = $Text.Trim()
+    $Text = $Text -replace '\s+', ' '
+
+    return $Text
+}
+
+function Get-ITGlueAttachmentName {
+param(
+    $Attachment
+)
+    @(
+        $Attachment.attributes.'file-name'
+        $Attachment.attributes.file_name
+        $Attachment.attributes.name
+        $Attachment.attributes.attachment.file_name
+        $Attachment.attributes.attachment.'file-name'
+        $Attachment.attributes.'attachment-file-name'
+        $Attachment.attributes.'attachment-file_name'
+    ) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -First 1
+}
+
+function Get-ITGlueAttachmentsForResource {
+param(
+    [string]$ResourceType,
+    [string]$ResourceId
+)
+    if ([string]::IsNullOrWhiteSpace($ResourceType) -or [string]::IsNullOrWhiteSpace($ResourceId)) { return @() }
+    if ([string]::IsNullOrWhiteSpace($ITGKey)) { return @() }
+
+    $CacheKey = "$ResourceType/$ResourceId"
+    if ($script:ITGlueAttachmentCache.ContainsKey($CacheKey)) { return $script:ITGlueAttachmentCache[$CacheKey] }
+
+    $ApiBase = @($ITGAPIEndpoint, $settings.ITGAPIEndpoint, $environmentSettings.ITGAPIEndpoint) |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+        Select-Object -First 1
+
+    if ([string]::IsNullOrWhiteSpace($ApiBase)) { return @() }
+
+    $ApiBase = $ApiBase.TrimEnd('/')
+    $Uri = "$ApiBase/$ResourceType/$ResourceId/relationships/attachments?page%5Bsize%5D=1000"
+
+    try {
+        $Response = Invoke-RestMethod -Method GET -Uri $Uri -Headers @{ 'x-api-key' = $ITGKey } -ErrorAction Stop
+        $Attachments = @($Response.data)
+    }
+    catch {
+        Write-Warning "Unable to retrieve IT Glue attachments for $ResourceType/$ResourceId. Attachment URL aliases may be incomplete. $($_.Exception.Message)"
+        $Attachments = @()
+    }
+
+    $script:ITGlueAttachmentCache[$CacheKey] = $Attachments
+    return $Attachments
+}
+
+function Find-ITGlueAttachmentForFile {
+param(
+    [System.IO.FileInfo]$FoundFile,
+    $FoundAsset,
+    [string]$UploadType
+)
+    $PathInfo = Get-AttachmentPathInfo -FoundFile $FoundFile
+    if (-not $PathInfo) { return $null }
+
+    $ResourceType = Get-ITGlueAttachmentResourceType -AttachmentType $PathInfo.AttachmentType -UploadType $UploadType
+    $Attachments = Get-ITGlueAttachmentsForResource -ResourceType $ResourceType -ResourceId $PathInfo.ITGID
+    if (-not $Attachments -or $Attachments.Count -lt 1) { return $null }
+
+    $ExpectedName = Normalize-ITGlueAttachmentFilename -Name $FoundFile.Name
+    $ExpectedStem = Normalize-ITGlueAttachmentFilename -Name ([IO.Path]::GetFileNameWithoutExtension($FoundFile.Name))
+
+    foreach ($Attachment in $Attachments) {
+        $AttachmentName = Get-ITGlueAttachmentName -Attachment $Attachment
+        $NormalizedName = Normalize-ITGlueAttachmentFilename -Name $AttachmentName
+        $NormalizedStem = Normalize-ITGlueAttachmentFilename -Name ([IO.Path]::GetFileNameWithoutExtension($AttachmentName))
+
+        if ($ExpectedName -and $ExpectedName -eq $NormalizedName) { return $Attachment }
+        if ($ExpectedStem -and $ExpectedStem -eq $NormalizedStem) { return $Attachment }
+    }
+
+    return $null
+}
+
+function Get-ITGlueAttachmentUrlAliases {
+param(
+    $Attachment
+)
+    if (-not $Attachment -or [string]::IsNullOrWhiteSpace($Attachment.id) -or [string]::IsNullOrWhiteSpace($ITGURL)) { return @() }
+
+    $AttachmentId = $Attachment.id
+    $BaseUrl = $ITGURL.TrimEnd('/')
+
+    @(
+        "$BaseUrl/attachments/$AttachmentId"
+        "$BaseUrl/attachments/$AttachmentId`?preview=1"
+        "$BaseUrl/attachments/$AttachmentId`?preview=true"
+        "/attachments/$AttachmentId"
+        "/attachments/$AttachmentId`?preview=1"
+        "/attachments/$AttachmentId`?preview=true"
+    )
 }
 
 function Save-AttachmentUrlMap {
@@ -156,10 +308,15 @@ param(
                     $HuduUpload = New-HuduUpload -FilePath $FoundFile.fullname -uploadable_id $FoundAsset.HuduID -uploadable_type $UploadType
                     $FullHuduUploadUrl = Resolve-HuduUploadUrl -Upload $HuduUpload
                     $OriginalAttachmentUrl = Get-OriginalAttachmentUrl -FoundFile $FoundFile -FoundAsset $FoundAsset
-                    Add-AttachmentUrlMapEntry -OriginalUrl $OriginalAttachmentUrl -HuduUrl $FullHuduUploadUrl
+                    $ITGlueAttachment = Find-ITGlueAttachmentForFile -FoundFile $FoundFile -FoundAsset $FoundAsset -UploadType $UploadType
+                    $OriginalAttachmentUrls = @($OriginalAttachmentUrl) + @(Get-ITGlueAttachmentUrlAliases -Attachment $ITGlueAttachment)
+                    $OriginalAttachmentUrls = @($OriginalAttachmentUrls | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+                    Add-AttachmentUrlMapEntry -OriginalUrl $OriginalAttachmentUrls -HuduUrl $FullHuduUploadUrl
                     [PSCustomObject]@{
                         URL  = $FullHuduUploadUrl
                         OriginalAttachmentUrl = $OriginalAttachmentUrl
+                        OriginalAttachmentUrls = $OriginalAttachmentUrls
+                        ITGAttachmentID = $ITGlueAttachment.id
                         Uploadable_ID = $FoundAsset.HuduID
                         Uploadable_Type = $UploadType
                         FilePath  = $FoundFile.fullname

--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -2314,7 +2314,7 @@ if ($true -eq $DisableWebsiteMonitoring) {write-host "leaving websites unmonitor
 
 write-host "wrapup 2/10... adding attachments and replacing any found attachment links (this can take a while)"
 . .\Add-HuduAttachmentsViaAPI.ps1
-Start-HuduAttachmentLinkReplacement
+$replacedAttachmentURLs = Start-HuduAttachmentLinkReplacement
 
 write-host "wrapup 3/10... Creating IPAM/Networks and Addresses if user-configured to do so... $($importChecklists)"
 if ($true -eq $ImportConfigInterfaces){

--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -76,6 +76,7 @@ $FontAwesomeUpgrade = Get-FontAwesomeMap
 . $PSScriptRoot\Public\JWT-Auth.ps1
 . $PSScriptRoot\Public\NetworkInformation.ps1
 . $PSScriptRoot\Public\PreFlightTests.ps1
+. $PSScriptRoot\Public\ReplaceAttachmentLinks.ps1
 ############################### End of Functions ###############################
 
 if (-not (Get-Command -Name Get-UserFlagSetup -ErrorAction SilentlyContinue)) { . $PSScriptRoot\Public\Add-OptionalFlags.ps1 }
@@ -2309,8 +2310,9 @@ write-host "wrapup 1/10... setting asset layouts as active, enabling advanced we
 foreach ($layout in Get-HuduAssetLayouts) {write-host "setting $($(Set-HuduAssetLayout -id $layout.id -Active $true).asset_layout.name) as active" }
 if ($true -eq $DisableWebsiteMonitoring) {write-host "leaving websites unmonitored per user-config"} else {$MatchedWebsites.HuduObject | Where-Object {$_.id -and $_.id -gt 0} | Foreach-Object {write-host "Enabling advanced monitoring features for $($(Set-HuduWebsite -id $_.id -EnableDMARC 'true' -EnableDKIM 'true' -EnableSPF 'true' -DisableDNS 'false' -DisableSSL 'false' -DisableWhois 'false' -Paused 'false').name)" -ForegroundColor DarkCyan}}
 
-write-host "wrapup 2/10... adding attachments (this can take a while)"
+write-host "wrapup 2/10... adding attachments and replacing any found attachment links (this can take a while)"
 . .\Add-HuduAttachmentsViaAPI.ps1
+Start-HuduAttachmentLinkReplacement
 
 write-host "wrapup 3/10... Creating IPAM/Networks and Addresses if user-configured to do so... $($importChecklists)"
 if ($true -eq $ImportConfigInterfaces){

--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -1484,7 +1484,8 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Assets.json")) {
 	
 	
         #We now need to loop through all Assets again updating the assets to their final version
-        foreach ($UpdateAsset in $MatchedAssets) {
+        
+        foreach ($UpdateAsset in $MatchedAssets | where-object {$_.ITGObject.attributes.archived -ne $true}) {
             Write-Host "Populating $($UpdateAsset.Name)"
 		
             $AssetFields = @{ 

--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -1485,7 +1485,8 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Assets.json")) {
 	
         #We now need to loop through all Assets again updating the assets to their final version
         
-        foreach ($UpdateAsset in $MatchedAssets | where-object {$_.ITGObject.attributes.archived -ne $true}) {
+        # foreach ($UpdateAsset in $MatchedAssets | where-object {$_.ITGObject.attributes.archived -ne $true}) {
+        foreach ($UpdateAsset in $MatchedAssets) {
             Write-Host "Populating $($UpdateAsset.Name)"
 		
             $AssetFields = @{ 

--- a/Private/Import-Items.ps1
+++ b/Private/Import-Items.ps1
@@ -96,10 +96,10 @@ function Import-Items {
         if (($importOption -eq "A") -or ($importOption -eq "S") ) {		
 	
             foreach ($company in $CompaniesToMigrate) {
-                if ($true -eq $itgimport.attributes.archived){
-                    write-host "SKIPPING ARCHIVED IMPORT: $($itgimport.attributes.name) is archived in ITGlue and is being skipped for migration" -ForegroundColor Yellow
-                    continue
-                }
+                # if ($true -eq $itgimport.attributes.archived){
+                #     write-host "SKIPPING ARCHIVED IMPORT: $($itgimport.attributes.name) is archived in ITGlue and is being skipped for migration" -ForegroundColor Yellow
+                #     continue
+                # }
 
                 Write-Host "Migrating $($company.CompanyName) $MigrationName"
 	
@@ -110,7 +110,7 @@ function Import-Items {
 					$AssetFields.'ITG Date Created' = $(Get-CoercedDate $unmatchedImport."ITGObject".attributes.'created-at')
 					$AssetFields.'ITG Date Last Updated' = $(Get-CoercedDate $unmatchedImport."ITGObject".attributes.'updated-at')
 
-                    Confirm-Import -ImportObjectName "$($unmatchedImport.Name): $($AssetFields | Out-String)" -ImportObject $unmatchedImport -ImportSetting $ImportOption
+                    Confirm-Import -ImportObjectName "$($unmatchedImport.Name): $($Assadd etFields | Out-String)" -ImportObject $unmatchedImport -ImportSetting $ImportOption
 	
                     Write-Host "Starting $($unmatchedImport.Name)"
 	

--- a/Private/Import-Items.ps1
+++ b/Private/Import-Items.ps1
@@ -96,6 +96,11 @@ function Import-Items {
         if (($importOption -eq "A") -or ($importOption -eq "S") ) {		
 	
             foreach ($company in $CompaniesToMigrate) {
+                if ($true -eq $itgimport.attributes.archived){
+                    write-host "SKIPPING ARCHIVED IMPORT: $($itgimport.attributes.name) is archived in ITGlue and is being skipped for migration" -ForegroundColor Yellow
+                    continue
+                }
+
                 Write-Host "Migrating $($company.CompanyName) $MigrationName"
 	
                 foreach ($unmatchedImport in ($MatchedImports | Where-Object { $_.Matched -eq $false -and $company.ITGCompanyObject.id -eq $_."ITGObject".attributes."organization-id" })) {

--- a/Private/Import-Items.ps1
+++ b/Private/Import-Items.ps1
@@ -110,8 +110,8 @@ function Import-Items {
 					$AssetFields.'ITG Date Created' = $(Get-CoercedDate $unmatchedImport."ITGObject".attributes.'created-at')
 					$AssetFields.'ITG Date Last Updated' = $(Get-CoercedDate $unmatchedImport."ITGObject".attributes.'updated-at')
 
-                    Confirm-Import -ImportObjectName "$($unmatchedImport.Name): $($Assadd etFields | Out-String)" -ImportObject $unmatchedImport -ImportSetting $ImportOption
-	
+                    Confirm-Import -ImportObjectName "$($unmatchedImport.Name): $($AssetFields | Out-String)" -ImportObject $unmatchedImport -ImportSetting $ImportOption
+                    	
                     Write-Host "Starting $($unmatchedImport.Name)"
 	
                     $HuduAssetName = $($unmatchedImport.Name)

--- a/Public/ReplaceAttachmentLinks.ps1
+++ b/Public/ReplaceAttachmentLinks.ps1
@@ -54,6 +54,7 @@ param(
                 $AttachmentPaths = @(
                     "/attachments/$AttachmentId"
                     "/attachments/$AttachmentId`?preview=1"
+                    "/attachments/$AttachmentId`?preview=true"
                 )
 
                 foreach ($AttachmentPath in $AttachmentPaths) {
@@ -66,6 +67,7 @@ param(
             $AttachmentId = $Matches.AttachmentId
             $Candidates += "/attachments/$AttachmentId"
             $Candidates += "/attachments/$AttachmentId`?preview=1"
+            $Candidates += "/attachments/$AttachmentId`?preview=true"
         }
     }
     catch {}
@@ -88,6 +90,21 @@ param(
     }
 }
 
+function Get-ITGlueAttachmentUrls {
+param(
+    [AllowEmptyString()]
+    [string]$Content
+)
+    if ([string]::IsNullOrWhiteSpace($Content)) { return @() }
+
+    $AttachmentPattern = '(?:https?://[^"''\s<>]+)?/attachments/\d{1,20}(?:\?preview=(?:1|true))?'
+    @(
+        [regex]::Matches($Content, $AttachmentPattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase) |
+            ForEach-Object { $_.Value } |
+            Select-Object -Unique
+    )
+}
+
 function Update-ContentWithAttachmentUrlMap {
 param(
     [AllowEmptyString()]
@@ -105,6 +122,9 @@ param(
             $CandidatePattern = [regex]::Escape($CandidateUrl)
             if ($Candidate.IsRelative) {
                 $CandidatePattern = "(?<![A-Za-z0-9._~%+-])$CandidatePattern"
+            }
+            if ($CandidateUrl -notmatch '\?' -and $CandidateUrl -match '/(?:files|attachments)/\d{1,20}$') {
+                $CandidatePattern = "$CandidatePattern(?![/?#])"
             }
 
             $Count = [regex]::Matches($NewContent, $CandidatePattern).Count
@@ -172,6 +192,19 @@ param(
 
         $Updated = Update-ContentWithAttachmentUrlMap -Content $Article.content -UrlMap $UrlMap
         if (-not $Updated.Changed) {
+            $UnresolvedAttachmentUrls = Get-ITGlueAttachmentUrls -Content $Article.content
+            if ($UnresolvedAttachmentUrls.Count -gt 0) {
+                [pscustomobject]@{
+                    Status                   = 'unresolved'
+                    ArticleId                = $Article.id
+                    ArticleName              = $Article.name
+                    Reason                   = 'attachment URLs found but no AttachmentUrlMap match'
+                    UnresolvedAttachmentUrls = $UnresolvedAttachmentUrls
+                    Replacements             = @()
+                }
+                continue
+            }
+
             [pscustomobject]@{
                 Status       = 'clean'
                 ArticleId    = $Article.id

--- a/Public/ReplaceAttachmentLinks.ps1
+++ b/Public/ReplaceAttachmentLinks.ps1
@@ -1,0 +1,167 @@
+function ConvertTo-AttachmentUrlHashtable {
+param(
+    $MapObject
+)
+    if ($MapObject -is [hashtable]) { return $MapObject }
+
+    $Hashtable = @{}
+
+    if ($MapObject -is [System.Collections.IDictionary]) {
+        foreach ($Key in $MapObject.Keys) {
+            $Hashtable[[string]$Key] = [string]$MapObject[$Key]
+        }
+        return $Hashtable
+    }
+
+    foreach ($Property in $MapObject.PSObject.Properties) {
+        if ($Property.MemberType -in 'NoteProperty','Property') {
+            $Hashtable[[string]$Property.Name] = [string]$Property.Value
+        }
+    }
+
+    return $Hashtable
+}
+
+function Get-AttachmentUrlMap {
+param(
+    [string]$MapPath = "$MigrationLogs\AttachmentUrlMap.json"
+)
+    if ($AttachmentUrlMap -and $AttachmentUrlMap.Count -gt 0) {
+        return ConvertTo-AttachmentUrlHashtable -MapObject $AttachmentUrlMap
+    }
+
+    if (-not (Test-Path $MapPath)) {
+        throw "Attachment URL map was not found at '$MapPath'. Run Add-HuduAttachmentsViaAPI.ps1 first."
+    }
+
+    $MapObject = Get-Content -Path $MapPath -Raw | ConvertFrom-Json -Depth 100
+    return ConvertTo-AttachmentUrlHashtable -MapObject $MapObject
+}
+
+function Update-ContentWithAttachmentUrlMap {
+param(
+    [AllowEmptyString()]
+    [string]$Content,
+    [hashtable]$UrlMap
+)
+    $NewContent = $Content
+    $Replacements = @()
+
+    foreach ($OriginalUrl in @($UrlMap.Keys | Sort-Object Length -Descending)) {
+        if ([string]::IsNullOrWhiteSpace($OriginalUrl) -or [string]::IsNullOrWhiteSpace($UrlMap[$OriginalUrl])) { continue }
+
+        $Candidates = @($OriginalUrl)
+        $HtmlEncodedOriginalUrl = [System.Net.WebUtility]::HtmlEncode($OriginalUrl)
+        if ($HtmlEncodedOriginalUrl -and $HtmlEncodedOriginalUrl -ne $OriginalUrl) {
+            $Candidates += $HtmlEncodedOriginalUrl
+        }
+
+        foreach ($CandidateUrl in $Candidates | Select-Object -Unique) {
+            $Count = [regex]::Matches($NewContent, [regex]::Escape($CandidateUrl)).Count
+            if ($Count -lt 1) { continue }
+
+            $ReplacementUrl = if ($CandidateUrl -eq $HtmlEncodedOriginalUrl) {
+                [System.Net.WebUtility]::HtmlEncode($UrlMap[$OriginalUrl])
+            } else {
+                $UrlMap[$OriginalUrl]
+            }
+
+            $NewContent = $NewContent.Replace($CandidateUrl, $ReplacementUrl)
+            $Replacements += [pscustomobject]@{
+                OriginalUrl    = $OriginalUrl
+                MatchedUrl     = $CandidateUrl
+                ReplacementUrl = $ReplacementUrl
+                Count          = $Count
+            }
+        }
+    }
+
+    [pscustomobject]@{
+        Content      = $NewContent
+        Changed      = ($NewContent -ne $Content)
+        Replacements = $Replacements
+    }
+}
+
+function Start-HuduAttachmentLinkReplacement {
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [object[]]$Articles,
+    [hashtable]$UrlMap,
+    [string]$MapPath = "$MigrationLogs\AttachmentUrlMap.json",
+    [string]$OutputPath = "$MigrationLogs\ReplacedAttachmentLinks.json"
+)
+    if (-not $UrlMap) {
+        $UrlMap = Get-AttachmentUrlMap -MapPath $MapPath
+    }
+
+    if (-not $UrlMap -or $UrlMap.Count -lt 1) {
+        Write-Warning "Attachment URL map is empty. No articles were updated."
+        return @()
+    }
+
+    if (-not $Articles) {
+        $Articles = @(Get-HuduArticles)
+    }
+
+    $Results = foreach ($Article in $Articles) {
+        if ([string]::IsNullOrEmpty($Article.content)) {
+            [pscustomobject]@{
+                Status       = 'skipped'
+                ArticleId    = $Article.id
+                ArticleName  = $Article.name
+                Reason       = 'empty content'
+                Replacements = @()
+            }
+            continue
+        }
+
+        $Updated = Update-ContentWithAttachmentUrlMap -Content $Article.content -UrlMap $UrlMap
+        if (-not $Updated.Changed) {
+            [pscustomobject]@{
+                Status       = 'clean'
+                ArticleId    = $Article.id
+                ArticleName  = $Article.name
+                Reason       = 'no attachment URLs found'
+                Replacements = @()
+            }
+            continue
+        }
+
+        Write-Host "Replacing $($Updated.Replacements.Count) attachment URL set(s) in article '$($Article.name)'" -ForegroundColor Green
+
+        try {
+            $UpdatedArticle = $null
+            if ($PSCmdlet.ShouldProcess("Article $($Article.id) '$($Article.name)'", "replace attachment links")) {
+                $SetArticleSplat = @{
+                    Id      = $Article.id
+                    Content = $Updated.Content
+                }
+                if ($Article.name) { $SetArticleSplat.Name = $Article.name }
+                if ($Article.company_id) { $SetArticleSplat.CompanyId = $Article.company_id }
+
+                $UpdatedArticle = Set-HuduArticle @SetArticleSplat -ErrorAction Stop
+            }
+
+            [pscustomobject]@{
+                Status       = if ($WhatIfPreference) { 'whatif' } else { 'replaced' }
+                ArticleId    = $Article.id
+                ArticleName  = $Article.name
+                Replacements = $Updated.Replacements
+                UpdatedArticle = $UpdatedArticle
+            }
+        }
+        catch {
+            [pscustomobject]@{
+                Status       = 'failed'
+                ArticleId    = $Article.id
+                ArticleName  = $Article.name
+                Error        = $_.Exception.Message
+                Replacements = $Updated.Replacements
+            }
+        }
+    }
+
+    $Results | ConvertTo-Json -Depth 100 | Out-File $OutputPath -WhatIf:$false
+    return $Results
+}

--- a/Public/ReplaceAttachmentLinks.ps1
+++ b/Public/ReplaceAttachmentLinks.ps1
@@ -38,6 +38,56 @@ param(
     return ConvertTo-AttachmentUrlHashtable -MapObject $MapObject
 }
 
+function Get-AttachmentUrlReplacementCandidates {
+param(
+    [string]$OriginalUrl
+)
+    $Candidates = @($OriginalUrl)
+
+    try {
+        $ParsedUrl = [Uri]$OriginalUrl
+        if ($ParsedUrl.IsAbsoluteUri) {
+            $Candidates += $ParsedUrl.PathAndQuery
+
+            if ($ParsedUrl.AbsolutePath -match '/(?:files|attachments)/(?<AttachmentId>\d{1,20})(?:/|$)') {
+                $AttachmentId = $Matches.AttachmentId
+                $AttachmentPaths = @(
+                    "/attachments/$AttachmentId"
+                    "/attachments/$AttachmentId`?preview=1"
+                )
+
+                foreach ($AttachmentPath in $AttachmentPaths) {
+                    $Candidates += $AttachmentPath
+                    $Candidates += "$($ParsedUrl.GetLeftPart([UriPartial]::Authority))$AttachmentPath"
+                }
+            }
+        }
+        elseif ($OriginalUrl -match '/(?:files|attachments)/(?<AttachmentId>\d{1,20})(?=$|[/?#])') {
+            $AttachmentId = $Matches.AttachmentId
+            $Candidates += "/attachments/$AttachmentId"
+            $Candidates += "/attachments/$AttachmentId`?preview=1"
+        }
+    }
+    catch {}
+
+    foreach ($Candidate in @($Candidates | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique | Sort-Object Length -Descending)) {
+        [pscustomobject]@{
+            Url           = $Candidate
+            IsHtmlEncoded = $false
+            IsRelative    = $Candidate.StartsWith('/')
+        }
+
+        $HtmlEncodedCandidate = [System.Net.WebUtility]::HtmlEncode($Candidate)
+        if ($HtmlEncodedCandidate -and $HtmlEncodedCandidate -ne $Candidate) {
+            [pscustomobject]@{
+                Url           = $HtmlEncodedCandidate
+                IsHtmlEncoded = $true
+                IsRelative    = $Candidate.StartsWith('/')
+            }
+        }
+    }
+}
+
 function Update-ContentWithAttachmentUrlMap {
 param(
     [AllowEmptyString()]
@@ -50,23 +100,27 @@ param(
     foreach ($OriginalUrl in @($UrlMap.Keys | Sort-Object Length -Descending)) {
         if ([string]::IsNullOrWhiteSpace($OriginalUrl) -or [string]::IsNullOrWhiteSpace($UrlMap[$OriginalUrl])) { continue }
 
-        $Candidates = @($OriginalUrl)
-        $HtmlEncodedOriginalUrl = [System.Net.WebUtility]::HtmlEncode($OriginalUrl)
-        if ($HtmlEncodedOriginalUrl -and $HtmlEncodedOriginalUrl -ne $OriginalUrl) {
-            $Candidates += $HtmlEncodedOriginalUrl
-        }
+        foreach ($Candidate in @(Get-AttachmentUrlReplacementCandidates -OriginalUrl $OriginalUrl)) {
+            $CandidateUrl = $Candidate.Url
+            $CandidatePattern = [regex]::Escape($CandidateUrl)
+            if ($Candidate.IsRelative) {
+                $CandidatePattern = "(?<![A-Za-z0-9._~%+-])$CandidatePattern"
+            }
 
-        foreach ($CandidateUrl in $Candidates | Select-Object -Unique) {
-            $Count = [regex]::Matches($NewContent, [regex]::Escape($CandidateUrl)).Count
+            $Count = [regex]::Matches($NewContent, $CandidatePattern).Count
             if ($Count -lt 1) { continue }
 
-            $ReplacementUrl = if ($CandidateUrl -eq $HtmlEncodedOriginalUrl) {
+            $ReplacementUrl = if ($Candidate.IsHtmlEncoded) {
                 [System.Net.WebUtility]::HtmlEncode($UrlMap[$OriginalUrl])
             } else {
                 $UrlMap[$OriginalUrl]
             }
 
-            $NewContent = $NewContent.Replace($CandidateUrl, $ReplacementUrl)
+            $NewContent = [regex]::Replace(
+                $NewContent,
+                $CandidatePattern,
+                [System.Text.RegularExpressions.MatchEvaluator]{ param($match) $ReplacementUrl }
+            )
             $Replacements += [pscustomobject]@{
                 OriginalUrl    = $OriginalUrl
                 MatchedUrl     = $CandidateUrl


### PR DESCRIPTION
source and link replacement step for article contents that includes all attachments in this hashtable
<img width="722" height="71" alt="image" src="https://github.com/user-attachments/assets/79325b3f-475d-4260-9c73-e5f1a0a9781c" />

This is mainly for:
Articles that include video embeds that point to video files that are attachments
articles that include image sources or links to attachments

this is because:
attachments run after the bulk of link replacement steps