### PR TITLE
Chore/testing richtextfield replace inter company

### DIFF
--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -2430,27 +2430,20 @@ foreach ($assetFound in $UpdateAssets.HuduObject) {
                 Write-Host "Replacing Asset $($assetFound.name) field $($FieldEntry.Label) with updated content" -ForegroundColor 'Red'
                 $customFields += @{ $label = $NewContent }
                 $replacedStatus = 'replaced'
-            } else {
-                $customFields += @{ $label = $FieldValue }
-            }
-        } else {
-            $customFields += @{ $label = $FieldValue }
+            } 
         }
     }
 
     if ($replacedStatus -eq 'replaced') {
         Write-Host "Updating Asset $($assetFound.name) with new custom_fields array" -ForegroundColor 'Green'
-        $AssetPost = Invoke-HuduRequest -Method PUT -Resource "api/v1/companies/$($assetFound.company_id)/assets/$($assetFound.id)" -Body @{
-            name              = $assetFound.name
-            asset_layout_id   = $assetFound.asset_layout_id
-            custom_fields     = $customFields
-        }
+        $AssetPost = Set-huduAsset -CompanyID $assetFound.company_id -Id $assetFound.id -fields @($customFields)
+        $AssetPost = $assetPost.asset ?? $assetPost
     }
 
     $assetsUpdated += @{
         status         = $replacedStatus
         original_asset = $originalAsset
-        updated_asset  = $AssetPost.asset
+        updated_asset  = $AssetPost
     }
 }
 

--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -2411,6 +2411,7 @@ $assetsUpdated = @()
 $AssetLayoutCache = @{}
 foreach ($assetFound in $UpdateAssets.HuduObject) {
     $originalAsset = $assetFound
+    $AssetPost = $null
     $replacedStatus = 'clean'
     $customFields = @()
 
@@ -2435,7 +2436,7 @@ foreach ($assetFound in $UpdateAssets.HuduObject) {
     }
 
     if ($replacedStatus -eq 'replaced') {
-        Write-Host "Updating Asset $($assetFound.name) with new custom_fields array" -ForegroundColor 'Green'
+        Write-Host "Updating Asset $($assetFound.name) with changed rich text field(s)" -ForegroundColor 'Green'
         $AssetPost = Set-huduAsset -CompanyID $assetFound.company_id -Id $assetFound.id -fields @($customFields)
         $AssetPost = $assetPost.asset ?? $assetPost
     }

--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -2378,7 +2378,7 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Passwords.json")) {
 $null = Start-MigrationJob -Name "LinkReplacement"
 
 $UpdateArticles = (Get-HuduArticles | Where-Object {$_.content -like "*$ITGURL*"})
-$UpdateAssets = $MatchedAssets | Where-Object {$_.HuduObject.fields.value -like "*$ITGURL*"}
+$UpdateAssets = $MatchedAssets | Where-Object {$_.HuduObject -and $_.HuduObject.fields}
 $UpdatePasswords = $MatchedPasswords | Where-Object {$_.HuduObject.description -like "*$ITGURL*"}
 $UpdateAssetPasswords = $MatchedAssetPasswords | Where-Object {$_.ITGObject.attributes.notes -like "*$ITGURL*"}
 $UpdateCompanyNotes = $MatchedCompanies | Where-Object {$_.HuduCompanyObject.notes -like "*$ITGURL*"}
@@ -2408,29 +2408,33 @@ Write-TimedMessage -Timeout 3 -Message "Snapshot Point: Article URLs Replaced. C
 
 # Assets
 $assetsUpdated = @()
+$AssetLayoutCache = @{}
 foreach ($assetFound in $UpdateAssets.HuduObject) {
     $originalAsset = $assetFound
     $replacedStatus = 'clean'
     $customFields = @()
 
     foreach ($field in $assetFound.fields) {
-        # Convert the caption to snake_case to match API expectations for 2.37.1
-        $label = ($field.caption -replace '[^\w\s]', '') -replace '\s+', '_' | ForEach-Object { $_.ToLower() }
+        $FieldEntry = Get-HuduAssetFieldEntry -Field $field
+        $label = $FieldEntry.Key
+        $FieldValue = $FieldEntry.Value
+        if ([string]::IsNullOrWhiteSpace($label)) { continue }
 
-        if ($label -in @('itglue_url', 'itglue_id', 'imported_from_itglue') -and $field.value -like "*$ITGURL*") {
-            $NewContent = Update-StringWithCaptureGroups -inputString $field.value -pattern $RichRegexPatternToMatchSansAssets -type "rich"
+        if (Test-HuduAssetFieldIsRichText -Asset $assetFound -Field $field -AssetLayoutCache $AssetLayoutCache) {
+            $NewContent = Update-StringWithCaptureGroups -inputString "$FieldValue" -pattern $RichRegexPatternToMatchSansAssets -type "rich"
             $NewContent = Update-StringWithCaptureGroups -inputString $NewContent -pattern $RichRegexPatternToMatchWithAssets -type "rich"
+            $NewContent = Update-StringWithCaptureGroups -inputString $NewContent -pattern $RichDocLocatorUrlPatternToMatch -type "rich"
+            $NewContent = Update-StringWithCaptureGroups -inputString $NewContent -pattern $RichDocLocatorRelativeURLPatternToMatch -type "rich"
 
-            if ($NewContent -and $NewContent -ne $field.value) {
-                Write-Host "Replacing Asset $($assetFound.name) field $($field.caption) with updated content" -ForegroundColor 'Red'
+            if ($NewContent -and $NewContent -ne $FieldValue) {
+                Write-Host "Replacing Asset $($assetFound.name) field $($FieldEntry.Label) with updated content" -ForegroundColor 'Red'
                 $customFields += @{ $label = $NewContent }
                 $replacedStatus = 'replaced'
             } else {
-                $customFields += @{ $label = $field.value }
+                $customFields += @{ $label = $FieldValue }
             }
         } else {
-            # For other fields, preserve existing value (optional)
-            $customFields += @{ $label = $field.value }
+            $customFields += @{ $label = $FieldValue }
         }
     }
 

--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -2111,6 +2111,7 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Articles.json")) {
         } 
 
         $MatchedArticles | ConvertTo-Json -depth 100 | Out-File "$MigrationLogs\Articles.json"
+        $ImageMap | ConvertTo-Json -depth 100 | Out-File "$MigrationLogs\ImageMap.json"
         $ArticleErrors | ConvertTo-Json -depth 100 | Out-File "$MigrationLogs\ArticleErrors.json"
         $ManualActions | ConvertTo-Json -depth 100 | Out-File "$MigrationLogs\ManualActions.json"
         Write-TimedMessage -Timeout 3 -Message "Snapshot Point: Articles Created Continue?" -DefaultResponse "continue to Passwords, please."

--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -2417,9 +2417,10 @@ foreach ($assetFound in $UpdateAssets.HuduObject) {
 
     foreach ($field in $assetFound.fields) {
         $FieldEntry = Get-HuduAssetFieldEntry -Field $field
-        $label = $FieldEntry.Key
+        $label = $FieldEntry.Label
         $FieldValue = $FieldEntry.Value
         if ([string]::IsNullOrWhiteSpace($label)) { continue }
+        if ([string]::IsNullOrWhiteSpace([string]$FieldValue)) { continue }
 
         if (Test-HuduAssetFieldIsRichText -Asset $assetFound -Field $field -AssetLayoutCache $AssetLayoutCache) {
             $NewContent = Update-StringWithCaptureGroups -inputString "$FieldValue" -pattern $RichRegexPatternToMatchSansAssets -type "rich"

--- a/Private/ConvertTo-HuduURL.ps1
+++ b/Private/ConvertTo-HuduURL.ps1
@@ -33,6 +33,175 @@ $TextRegexPatternToMatchSansAssets = "$EscapedITGURL/([0-9]{1,20})/(docs|passwor
 $TextRegexPatternToMatchWithAssets = "$EscapedITGURL/([0-9]{1,20})/(assets)/.*?/([0-9]{1,20})"
 $TextDocLocatorUrlPatternToMatch = "$EscapedITGURL/(DOC-[0-9]{0,20}-[0-9]{0,20}).*(?= )"
 
+function Remove-ITGlueUrlSuffixJunk {
+    param(
+        [AllowEmptyString()]
+        [string]$Url
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Url)) { return $Url }
+
+    $DecodedUrl = [System.Net.WebUtility]::HtmlDecode($Url)
+    if ($DecodedUrl -match '[?#].*(version=|documentMode=|preview(?:=|&|$)|edit(?:=|&|$))') {
+        return ($DecodedUrl -split '[?#]', 2)[0]
+    }
+
+    return $DecodedUrl
+}
+
+function Get-HuduUrlRewriteTarget {
+    param(
+        $MatchedItem,
+        [string]$FallbackName
+    )
+
+    if (-not $MatchedItem) { return $null }
+    $Item = @($MatchedItem | Select-Object -First 1)[0]
+    if (-not $Item) { return $null }
+
+    $HuduObject = $Item.HuduObject
+    if (-not $HuduObject -and $Item.HuduCompanyObject) { $HuduObject = $Item.HuduCompanyObject }
+    if (-not $HuduObject -and $Item.HuduCompany) { $HuduObject = $Item.HuduCompany }
+
+    $HuduUrl = $HuduObject.url
+    if (-not $HuduUrl -and $Item.url) { $HuduUrl = $Item.url }
+    if (-not $HuduUrl -and $HuduBaseDomain -and $Item.HuduID) {
+        $HuduUrl = "$($HuduBaseDomain.TrimEnd('/'))/companies/$($Item.HuduID)"
+    }
+
+    if (-not $HuduUrl) { return $null }
+
+    $HuduName = $HuduObject.name
+    if (-not $HuduName) { $HuduName = $Item.Name }
+    if (-not $HuduName) { $HuduName = $FallbackName }
+
+    [pscustomobject]@{
+        Url  = $HuduUrl.replace('http://','https://')
+        Name = $HuduName
+    }
+}
+
+function Test-ITGlueHrefCandidate {
+    param(
+        [AllowEmptyString()]
+        [string]$Href
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Href)) { return $false }
+
+    $DecodedHref = [System.Net.WebUtility]::HtmlDecode($Href)
+    if ($DecodedHref -match "^$EscapedITGURL(?:/|$)") { return $true }
+    if ($DecodedHref -match '^/?DOC-[0-9]{1,20}-[0-9]{1,20}(?:[?#].*)?$') { return $true }
+    if ($DecodedHref -match '^/[0-9]{1,20}/(docs|passwords|configurations|assets|domains)(?:/|[?#]|$)') { return $true }
+
+    return $false
+}
+
+function Resolve-ITGlueHrefToHuduTarget {
+    param(
+        [string]$Href
+    )
+
+    if (-not (Test-ITGlueHrefCandidate -Href $Href)) { return $null }
+
+    $CleanHref = Remove-ITGlueUrlSuffixJunk -Url $Href
+    if ([string]::IsNullOrWhiteSpace($CleanHref)) { return $null }
+
+    if ($CleanHref -match '^/?(?<Locator>DOC-[0-9]{1,20}-[0-9]{1,20})$') {
+        return Get-HuduUrlRewriteTarget -MatchedItem ($MatchedArticles | Where-Object { $_.ITGLocator -eq $Matches.Locator }) -FallbackName $Matches.Locator
+    }
+
+    $Path = [regex]::Replace($CleanHref, "^$EscapedITGURL", '')
+    if ($Path -notmatch '^/') { return $null }
+
+    if ($Path -notmatch '^/(?<CompanyId>[0-9]{1,20})/(?<Resource>docs|passwords|configurations|assets|domains)(?:/(?<Rest>[^?#]*))?$') {
+        return $null
+    }
+
+    $CompanyId = $Matches.CompanyId
+    $Resource = $Matches.Resource
+    $Rest = $Matches.Rest
+    $IdMatches = [regex]::Matches($Rest, '[0-9]{1,20}')
+    $ResourceId = if ($IdMatches.Count -gt 0) { $IdMatches[$IdMatches.Count - 1].Value } else { $null }
+
+    switch ($Resource) {
+        'docs' {
+            if ($ResourceId) {
+                return Get-HuduUrlRewriteTarget -MatchedItem ($MatchedArticles | Where-Object { $_.ITGID -eq $ResourceId }) -FallbackName "Document $ResourceId"
+            }
+        }
+        'passwords' {
+            if ($ResourceId) {
+                $PasswordMatch = @($MatchedPasswords | Where-Object { $_.ITGID -eq $ResourceId })
+                if (-not $PasswordMatch -or $PasswordMatch.Count -lt 1) {
+                    $PasswordMatch = @($MatchedAssetPasswords | Where-Object { $_.ITGID -eq $ResourceId })
+                }
+                return Get-HuduUrlRewriteTarget -MatchedItem $PasswordMatch -FallbackName "Password $ResourceId"
+            }
+        }
+        'configurations' {
+            if ($ResourceId) {
+                return Get-HuduUrlRewriteTarget -MatchedItem ($MatchedConfigurations | Where-Object { $_.ITGID -eq $ResourceId }) -FallbackName "Configuration $ResourceId"
+            }
+        }
+        'assets' {
+            if ($ResourceId) {
+                return Get-HuduUrlRewriteTarget -MatchedItem ($MatchedAssets | Where-Object { $_.ITGID -eq $ResourceId }) -FallbackName "Asset $ResourceId"
+            }
+        }
+        'domains' {
+            if ($ResourceId) {
+                return Get-HuduUrlRewriteTarget -MatchedItem ($MatchedWebsites | Where-Object { $_.ITGID -eq $ResourceId }) -FallbackName "Domain $ResourceId"
+            }
+
+            return Get-HuduUrlRewriteTarget -MatchedItem ($MatchedCompanies | Where-Object { $_.ITGID -eq $CompanyId }) -FallbackName "Company $CompanyId"
+        }
+    }
+
+    return $null
+}
+
+function Update-HuduRichTextITGlueHrefs {
+    param(
+        [AllowEmptyString()]
+        [string]$Content
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Content)) { return $Content }
+
+    $HrefPattern = '(?i)(?<Prefix>\bhref\s*=\s*)(?<Quote>["''])(?<Href>.*?)(\k<Quote>)'
+
+    [regex]::Replace(
+        $Content,
+        $HrefPattern,
+        [System.Text.RegularExpressions.MatchEvaluator]{
+            param($Match)
+
+            $OriginalHref = $Match.Groups['Href'].Value
+            $IsITGlueHref = Test-ITGlueHrefCandidate -Href $OriginalHref
+            $CleanHref = if ($IsITGlueHref) {
+                Remove-ITGlueUrlSuffixJunk -Url $OriginalHref
+            } else {
+                [System.Net.WebUtility]::HtmlDecode($OriginalHref)
+            }
+            $Target = Resolve-ITGlueHrefToHuduTarget -Href $OriginalHref
+
+            $ReplacementHref = if ($Target -and $Target.Url) {
+                $Target.Url
+            } elseif ($IsITGlueHref -and $CleanHref -ne [System.Net.WebUtility]::HtmlDecode($OriginalHref)) {
+                $CleanHref
+            } else {
+                $null
+            }
+
+            if (-not $ReplacementHref) { return $Match.Value }
+
+            $EncodedHref = [System.Net.WebUtility]::HtmlEncode($ReplacementHref)
+            return "$($Match.Groups['Prefix'].Value)$($Match.Groups['Quote'].Value)$EncodedHref$($Match.Groups['Quote'].Value)"
+        }
+    )
+}
+
 function Update-StringWithCaptureGroups {
     [cmdletbinding()]
     param (
@@ -43,6 +212,10 @@ function Update-StringWithCaptureGroups {
       [Parameter(Mandatory=$true, Position=2)]
       [string]$type
     )
+
+    if ($type -eq 'rich') {
+        $inputString = Update-HuduRichTextITGlueHrefs -Content $inputString
+    }
   
     $regex = [regex]::new($pattern)
     

--- a/Private/ConvertTo-HuduURL.ps1
+++ b/Private/ConvertTo-HuduURL.ps1
@@ -81,6 +81,51 @@ function Get-HuduUrlRewriteTarget {
     }
 }
 
+function Get-ImageMapValue {
+    param(
+        [string]$ImageId
+    )
+
+    if ([string]::IsNullOrWhiteSpace($ImageId) -or -not $ImageMap) { return $null }
+
+    if ($ImageMap -is [System.Collections.IDictionary]) {
+        if ($ImageMap.ContainsKey($ImageId)) { return $ImageMap[$ImageId] }
+
+        foreach ($Key in $ImageMap.Keys) {
+            if ((Split-Path "$Key" -Leaf) -eq $ImageId) {
+                return $ImageMap[$Key]
+            }
+        }
+
+        return $null
+    }
+
+    $Property = $ImageMap.PSObject.Properties[$ImageId]
+    if ($Property) { return $Property.Value }
+
+    foreach ($Property in $ImageMap.PSObject.Properties) {
+        if ((Split-Path "$($Property.Name)" -Leaf) -eq $ImageId) {
+            return $Property.Value
+        }
+    }
+
+    return $null
+}
+
+function Get-HuduImageUrlRewriteTarget {
+    param(
+        [string]$ImageId
+    )
+
+    $ImageUrl = Get-ImageMapValue -ImageId $ImageId
+    if (-not $ImageUrl) { return $null }
+
+    [pscustomobject]@{
+        Url  = $ImageUrl
+        Name = "Image $ImageId"
+    }
+}
+
 function Test-ITGlueHrefCandidate {
     param(
         [AllowEmptyString()]
@@ -92,7 +137,7 @@ function Test-ITGlueHrefCandidate {
     $DecodedHref = [System.Net.WebUtility]::HtmlDecode($Href)
     if ($DecodedHref -match "^$EscapedITGURL(?:/|$)") { return $true }
     if ($DecodedHref -match '^/?DOC-[0-9]{1,20}-[0-9]{1,20}(?:[?#].*)?$') { return $true }
-    if ($DecodedHref -match '^/[0-9]{1,20}/(docs|passwords|configurations|assets|domains)(?:/|[?#]|$)') { return $true }
+    if ($DecodedHref -match '^/[0-9]{1,20}/(docs|passwords|configurations|assets|domains|contacts)(?:/|[?#]|$)') { return $true }
 
     return $false
 }
@@ -114,7 +159,7 @@ function Resolve-ITGlueHrefToHuduTarget {
     $Path = [regex]::Replace($CleanHref, "^$EscapedITGURL", '')
     if ($Path -notmatch '^/') { return $null }
 
-    if ($Path -notmatch '^/(?<CompanyId>[0-9]{1,20})/(?<Resource>docs|passwords|configurations|assets|domains)(?:/(?<Rest>[^?#]*))?$') {
+    if ($Path -notmatch '^/(?<CompanyId>[0-9]{1,20})/(?<Resource>docs|passwords|configurations|assets|domains|contacts)(?:/(?<Rest>[^?#]*))?$') {
         return $null
     }
 
@@ -123,6 +168,10 @@ function Resolve-ITGlueHrefToHuduTarget {
     $Rest = $Matches.Rest
     $IdMatches = [regex]::Matches($Rest, '[0-9]{1,20}')
     $ResourceId = if ($IdMatches.Count -gt 0) { $IdMatches[$IdMatches.Count - 1].Value } else { $null }
+
+    if ($Resource -eq 'docs' -and $Rest -match '^(?<DocId>[0-9]{1,20})/images/(?<ImageId>[0-9]{1,20})') {
+        return Get-HuduImageUrlRewriteTarget -ImageId $Matches.ImageId
+    }
 
     switch ($Resource) {
         'docs' {
@@ -149,12 +198,17 @@ function Resolve-ITGlueHrefToHuduTarget {
                 return Get-HuduUrlRewriteTarget -MatchedItem ($MatchedAssets | Where-Object { $_.ITGID -eq $ResourceId }) -FallbackName "Asset $ResourceId"
             }
         }
+        'contacts' {
+            if ($ResourceId) {
+                return Get-HuduUrlRewriteTarget -MatchedItem ($MatchedContacts | Where-Object { $_.ITGID -eq $ResourceId }) -FallbackName "Contact $ResourceId"
+            }
+        }
         'domains' {
             if ($ResourceId) {
                 return Get-HuduUrlRewriteTarget -MatchedItem ($MatchedWebsites | Where-Object { $_.ITGID -eq $ResourceId }) -FallbackName "Domain $ResourceId"
             }
 
-            return Get-HuduUrlRewriteTarget -MatchedItem ($MatchedCompanies | Where-Object { $_.ITGID -eq $CompanyId }) -FallbackName "Company $CompanyId"
+            return $null
         }
     }
 
@@ -169,27 +223,27 @@ function Update-HuduRichTextITGlueHrefs {
 
     if ([string]::IsNullOrWhiteSpace($Content)) { return $Content }
 
-    $HrefPattern = '(?i)(?<Prefix>\bhref\s*=\s*)(?<Quote>["''])(?<Href>.*?)(\k<Quote>)'
+    $UrlAttributePattern = '(?i)(?<Prefix>\b(?:href|src)\s*=\s*)(?<Quote>["''])(?<Url>.*?)(\k<Quote>)'
 
     [regex]::Replace(
         $Content,
-        $HrefPattern,
+        $UrlAttributePattern,
         [System.Text.RegularExpressions.MatchEvaluator]{
             param($Match)
 
-            $OriginalHref = $Match.Groups['Href'].Value
-            $IsITGlueHref = Test-ITGlueHrefCandidate -Href $OriginalHref
-            $CleanHref = if ($IsITGlueHref) {
-                Remove-ITGlueUrlSuffixJunk -Url $OriginalHref
+            $OriginalUrl = $Match.Groups['Url'].Value
+            $IsITGlueUrl = Test-ITGlueHrefCandidate -Href $OriginalUrl
+            $CleanUrl = if ($IsITGlueUrl) {
+                Remove-ITGlueUrlSuffixJunk -Url $OriginalUrl
             } else {
-                [System.Net.WebUtility]::HtmlDecode($OriginalHref)
+                [System.Net.WebUtility]::HtmlDecode($OriginalUrl)
             }
-            $Target = Resolve-ITGlueHrefToHuduTarget -Href $OriginalHref
+            $Target = Resolve-ITGlueHrefToHuduTarget -Href $OriginalUrl
 
             $ReplacementHref = if ($Target -and $Target.Url) {
                 $Target.Url
-            } elseif ($IsITGlueHref -and $CleanHref -ne [System.Net.WebUtility]::HtmlDecode($OriginalHref)) {
-                $CleanHref
+            } elseif ($IsITGlueUrl -and $CleanUrl -ne [System.Net.WebUtility]::HtmlDecode($OriginalUrl)) {
+                $CleanUrl
             } else {
                 $null
             }

--- a/Private/Mount-HuduMigrationLogs.ps1
+++ b/Private/Mount-HuduMigrationLogs.ps1
@@ -8,6 +8,7 @@ if (-not $MatchedCompanies -and (Test-Path -LiteralPath "$MigrationLogs\Companie
 if (-not $MatchedLocations -and (Test-Path -LiteralPath "$MigrationLogs\Locations.json")) {$MatchedLocations = (Get-Content -path "$MigrationLogs\Locations.json" | ConvertFrom-json -depth 100) }
 if (-not $MatchedPasswords -and (Test-Path -LiteralPath "$MigrationLogs\Passwords.json")) {$MatchedPasswords = (Get-Content -path "$MigrationLogs\Passwords.json" | ConvertFrom-json -depth 100) }
 if (-not $MatchedWebsites -and (Test-Path -LiteralPath "$MigrationLogs\websites.json")) {$MatchedWebsites = (Get-Content -path "$MigrationLogs\websites.json" | ConvertFrom-json -depth 100) }
+if (-not $ImageMap -and (Test-Path -LiteralPath "$MigrationLogs\ImageMap.json")) {$ImageMap = (Get-Content -path "$MigrationLogs\ImageMap.json" | ConvertFrom-json -depth 100) }
 if (-not $MatchedAssetLayoutFields -and (Test-Path -LiteralPath "$MigrationLogs\AssetLayoutsFields.json")) {$MatchedAssetLayoutFields = (Get-Content -path "$MigrationLogs\AssetLayoutsFields.json" | ConvertFrom-json -depth 100) }
 if (-not $RelationsToCreate -and (Test-Path -LiteralPath "$MigrationLogs\RelationsToCreate.json")) {$RelationsToCreate = (Get-Content -path "$MigrationLogs\RelationsToCreate.json" | ConvertFrom-json -depth 100) }
 if (-not $matchedChecklists -and (Test-Path -LiteralPath "$MigrationLogs\Checklists.json")) {$matchedChecklists = (Get-Content -path "$MigrationLogs\Checklists.json" | ConvertFrom-json -depth 100) }

--- a/Public/ReplaceAttachmentLinks.ps1
+++ b/Public/ReplaceAttachmentLinks.ps1
@@ -157,10 +157,334 @@ param(
     }
 }
 
+function ConvertTo-HuduAssetFieldKey {
+param(
+    [string]$Label
+)
+    if ([string]::IsNullOrWhiteSpace($Label)) { return $null }
+
+    (($Label -replace '[^\w\s]', '') -replace '\s+', '_').ToLower()
+}
+
+function Get-HuduAssetObject {
+param(
+    $Asset
+)
+    if ($Asset.HuduObject) { return $Asset.HuduObject }
+    return $Asset
+}
+
+function Get-HuduAssetFieldLabel {
+param(
+    $Field
+)
+    if ($Field -is [System.Collections.IDictionary] -and $Field.Keys.Count -eq 1) {
+        return [string]@($Field.Keys)[0]
+    }
+
+    $Properties = @($Field.PSObject.Properties | Where-Object { $_.MemberType -in 'NoteProperty','Property' })
+    if ($Properties.Count -eq 1) {
+        return [string]$Properties[0].Name
+    }
+
+    @(
+        $Field.label
+        $Field.caption
+        $Field.name
+    ) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -First 1
+}
+
+function Get-HuduAssetFieldEntry {
+param(
+    $Field
+)
+    if ($Field -is [System.Collections.IDictionary] -and $Field.Keys.Count -eq 1) {
+        $Key = [string]@($Field.Keys)[0]
+        return [pscustomobject]@{
+            Label = $Key
+            Key   = ConvertTo-HuduAssetFieldKey -Label $Key
+            Value = $Field[$Key]
+        }
+    }
+
+    $Properties = @($Field.PSObject.Properties | Where-Object { $_.MemberType -in 'NoteProperty','Property' })
+    if ($Properties.Count -eq 1) {
+        return [pscustomobject]@{
+            Label = [string]$Properties[0].Name
+            Key   = ConvertTo-HuduAssetFieldKey -Label $Properties[0].Name
+            Value = $Properties[0].Value
+        }
+    }
+
+    $Label = Get-HuduAssetFieldLabel -Field $Field
+    return [pscustomobject]@{
+        Label = $Label
+        Key   = ConvertTo-HuduAssetFieldKey -Label $Label
+        Value = $Field.value
+    }
+}
+
+function Get-HuduAssetLayoutId {
+param(
+    $Asset
+)
+    $LayoutId = $Asset.asset_layout_id
+    if (-not $LayoutId -and $Asset.asset_layout) {
+        $LayoutId = $Asset.asset_layout.id
+    }
+    return $LayoutId
+}
+
+function Get-HuduAssetLayoutFields {
+param(
+    $Asset,
+    [object[]]$AssetLayouts,
+    [hashtable]$AssetLayoutCache
+)
+    if ($Asset.asset_layout) {
+        $EmbeddedFields = @($Asset.asset_layout.field) + @($Asset.asset_layout.fields)
+        $EmbeddedFields = @($EmbeddedFields | Where-Object { $_ })
+        if ($EmbeddedFields.Count -gt 0) { return $EmbeddedFields }
+    }
+
+    $LayoutId = Get-HuduAssetLayoutId -Asset $Asset
+    if (-not $LayoutId) { return @() }
+
+    if ($AssetLayoutCache -and $AssetLayoutCache.ContainsKey([string]$LayoutId)) {
+        $CachedLayout = $AssetLayoutCache[[string]$LayoutId]
+        return @($CachedLayout.field) + @($CachedLayout.fields) | Where-Object { $_ }
+    }
+
+    $Layout = $null
+    if ($AssetLayouts) {
+        $Layout = $AssetLayouts | Where-Object {
+            $_.id -eq $LayoutId -or $_.HuduID -eq $LayoutId -or $_.HuduObject.id -eq $LayoutId
+        } | Select-Object -First 1
+        if ($Layout.HuduObject) { $Layout = $Layout.HuduObject }
+        if ($Layout.asset_layout) { $Layout = $Layout.asset_layout }
+    }
+
+    if (-not $Layout -and $MatchedLayouts) {
+        $Layout = $MatchedLayouts | Where-Object {
+            $_.id -eq $LayoutId -or $_.HuduID -eq $LayoutId -or $_.HuduObject.id -eq $LayoutId
+        } | Select-Object -First 1
+        if ($Layout.HuduObject) { $Layout = $Layout.HuduObject }
+        if ($Layout.asset_layout) { $Layout = $Layout.asset_layout }
+    }
+
+    if (-not $Layout -and (Get-Command Get-HuduAssetLayouts -ErrorAction SilentlyContinue)) {
+        $Layout = Get-HuduAssetLayouts -layoutid $LayoutId
+        if ($Layout.asset_layout) { $Layout = $Layout.asset_layout }
+    }
+
+    if ($Layout -and $AssetLayoutCache) {
+        $AssetLayoutCache[[string]$LayoutId] = $Layout
+    }
+
+    return @($Layout.field) + @($Layout.fields) | Where-Object { $_ }
+}
+
+function Test-HuduAssetFieldIsRichText {
+param(
+    $Asset,
+    $Field,
+    [object[]]$AssetLayouts,
+    [hashtable]$AssetLayoutCache
+)
+    $FieldEntry = Get-HuduAssetFieldEntry -Field $Field
+    $FieldLabel = $FieldEntry.Label
+    $FieldKey = $FieldEntry.Key
+
+    $FieldTypeValues = @(
+        $Field.field_type
+        $Field.fieldType
+        $Field.type
+        $Field.field_kind
+        $Field.kind
+    ) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+
+    if ($FieldTypeValues | Where-Object { "$_" -ieq 'RichText' -or "$_" -ieq 'Textbox' }) {
+        return $true
+    }
+
+    $LayoutFields = Get-HuduAssetLayoutFields -Asset $Asset -AssetLayouts $AssetLayouts -AssetLayoutCache $AssetLayoutCache
+    foreach ($LayoutField in $LayoutFields) {
+        $LayoutFieldLabel = $LayoutField.label
+        if ([string]::IsNullOrWhiteSpace($LayoutFieldLabel)) { $LayoutFieldLabel = $LayoutField.name }
+        if ([string]::IsNullOrWhiteSpace($LayoutFieldLabel)) { $LayoutFieldLabel = $LayoutField.caption }
+        $LayoutFieldKey = ConvertTo-HuduAssetFieldKey -Label $LayoutFieldLabel
+        if ($LayoutFieldKey -eq $FieldKey) {
+            return ($LayoutField.field_type -ieq 'RichText')
+        }
+    }
+
+    $LayoutId = Get-HuduAssetLayoutId -Asset $Asset
+    if ($AllFields -and $FieldKey) {
+        $MatchedField = $AllFields | Where-Object {
+            $FieldMatches = $_.HuduParsedName -eq $FieldKey -or $_.FieldName -eq $FieldLabel
+            $LayoutMatches = -not $LayoutId -or $_.HuduLayoutID -eq $LayoutId
+            $FieldMatches -and $LayoutMatches
+        } | Select-Object -First 1
+
+        if ($MatchedField) {
+            if ($MatchedField.HuduLayoutField.field_type -ieq 'RichText') { return $true }
+            if ($MatchedField.FieldType -ieq 'Textbox') { return $true }
+            if ($MatchedField.FieldType -ieq 'RichText') { return $true }
+            return $false
+        }
+    }
+
+    if ($FieldEntry.Value -is [string] -and $FieldEntry.Value -match '<(?:a|p|br|div|span|table|ul|ol|li|img)\b') {
+        return $true
+    }
+
+    return $false
+}
+
+function Get-HuduAssetsForAttachmentLinkReplacement {
+    if ($MatchedAssets) {
+        return @($MatchedAssets | ForEach-Object { Get-HuduAssetObject -Asset $_ } | Where-Object { $_ })
+    }
+
+    if (Get-Command Get-HuduAssets -ErrorAction SilentlyContinue) {
+        return @(Get-HuduAssets)
+    }
+
+    return @()
+}
+
+function Update-HuduAssetFieldsWithAttachmentUrlMap {
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [object[]]$Assets,
+    [hashtable]$UrlMap,
+    [object[]]$AssetLayouts
+)
+    $AssetLayoutCache = @{}
+    $Results = foreach ($AssetInput in $Assets) {
+        $Asset = Get-HuduAssetObject -Asset $AssetInput
+        if (-not $Asset -or -not $Asset.fields) {
+            [pscustomobject]@{
+                Status       = 'skipped'
+                ObjectType   = 'asset'
+                AssetId      = $Asset.id
+                AssetName    = $Asset.name
+                Reason       = 'no fields'
+                Replacements = @()
+            }
+            continue
+        }
+
+        $CustomFields = @()
+        $AssetReplacements = @()
+        $UnresolvedAttachmentUrls = @()
+
+        foreach ($Field in $Asset.fields) {
+            $FieldEntry = Get-HuduAssetFieldEntry -Field $Field
+            $FieldLabel = $FieldEntry.Label
+            $FieldKey = $FieldEntry.Key
+            if ([string]::IsNullOrWhiteSpace($FieldKey)) { continue }
+
+            $FieldValue = $FieldEntry.Value
+            if (Test-HuduAssetFieldIsRichText -Asset $Asset -Field $Field -AssetLayouts $AssetLayouts -AssetLayoutCache $AssetLayoutCache) {
+                $Updated = Update-ContentWithAttachmentUrlMap -Content "$FieldValue" -UrlMap $UrlMap
+
+                if ($Updated.Changed) {
+                    Write-Host "Replacing $($Updated.Replacements.Count) attachment URL set(s) in asset '$($Asset.name)' field '$FieldLabel'" -ForegroundColor Green
+                    $FieldValue = $Updated.Content
+                    $AssetReplacements += foreach ($Replacement in $Updated.Replacements) {
+                        [pscustomobject]@{
+                            FieldName      = $FieldLabel
+                            OriginalUrl    = $Replacement.OriginalUrl
+                            MatchedUrl     = $Replacement.MatchedUrl
+                            ReplacementUrl = $Replacement.ReplacementUrl
+                            Count          = $Replacement.Count
+                        }
+                    }
+                }
+                else {
+                    $UnresolvedAttachmentUrls += Get-ITGlueAttachmentUrls -Content "$FieldValue" |
+                        ForEach-Object {
+                            [pscustomobject]@{
+                                FieldName = $FieldLabel
+                                Url       = $_
+                            }
+                        }
+                }
+            }
+
+            $CustomFields += @{ $FieldKey = $FieldValue }
+        }
+
+        if ($AssetReplacements.Count -lt 1) {
+            if ($UnresolvedAttachmentUrls.Count -gt 0) {
+                [pscustomobject]@{
+                    Status                   = 'unresolved'
+                    ObjectType               = 'asset'
+                    AssetId                  = $Asset.id
+                    AssetName                = $Asset.name
+                    Reason                   = 'attachment URLs found in rich text fields but no AttachmentUrlMap match'
+                    UnresolvedAttachmentUrls = $UnresolvedAttachmentUrls
+                    Replacements             = @()
+                }
+                continue
+            }
+
+            [pscustomobject]@{
+                Status       = 'clean'
+                ObjectType   = 'asset'
+                AssetId      = $Asset.id
+                AssetName    = $Asset.name
+                Reason       = 'no attachment URLs found in rich text fields'
+                Replacements = @()
+            }
+            continue
+        }
+
+        try {
+            $UpdatedAsset = $null
+            if ($PSCmdlet.ShouldProcess("Asset $($Asset.id) '$($Asset.name)'", "replace attachment links in rich text fields")) {
+                $AssetPost = Invoke-HuduRequest -Method PUT -Resource "api/v1/companies/$($Asset.company_id)/assets/$($Asset.id)" -Body @{
+                    name            = $Asset.name
+                    asset_layout_id = Get-HuduAssetLayoutId -Asset $Asset
+                    custom_fields   = $CustomFields
+                } -ErrorAction Stop
+                $UpdatedAsset = $AssetPost.asset
+                if (-not $UpdatedAsset) {
+                    $UpdatedAsset = $AssetPost
+                }
+            }
+
+            [pscustomobject]@{
+                Status       = if ($WhatIfPreference) { 'whatif' } else { 'replaced' }
+                ObjectType   = 'asset'
+                AssetId      = $Asset.id
+                AssetName    = $Asset.name
+                Replacements = $AssetReplacements
+                UpdatedAsset = $UpdatedAsset
+            }
+        }
+        catch {
+            [pscustomobject]@{
+                Status       = 'failed'
+                ObjectType   = 'asset'
+                AssetId      = $Asset.id
+                AssetName    = $Asset.name
+                Error        = $_.Exception.Message
+                Replacements = $AssetReplacements
+            }
+        }
+    }
+
+    return $Results
+}
+
 function Start-HuduAttachmentLinkReplacement {
 [CmdletBinding(SupportsShouldProcess)]
 param(
     [object[]]$Articles,
+    [object[]]$Assets,
+    [object[]]$AssetLayouts,
     [hashtable]$UrlMap,
     [string]$MapPath = "$MigrationLogs\AttachmentUrlMap.json",
     [string]$OutputPath = "$MigrationLogs\ReplacedAttachmentLinks.json"
@@ -170,7 +494,7 @@ param(
     }
 
     if (-not $UrlMap -or $UrlMap.Count -lt 1) {
-        Write-Warning "Attachment URL map is empty. No articles were updated."
+        Write-Warning "Attachment URL map is empty. No articles or assets were updated."
         return @()
     }
 
@@ -178,10 +502,15 @@ param(
         $Articles = @(Get-HuduArticles)
     }
 
-    $Results = foreach ($Article in $Articles) {
+    if (-not $PSBoundParameters.ContainsKey('Assets')) {
+        $Assets = @(Get-HuduAssetsForAttachmentLinkReplacement)
+    }
+
+    $ArticleResults = foreach ($Article in $Articles) {
         if ([string]::IsNullOrEmpty($Article.content)) {
             [pscustomobject]@{
                 Status       = 'skipped'
+                ObjectType   = 'article'
                 ArticleId    = $Article.id
                 ArticleName  = $Article.name
                 Reason       = 'empty content'
@@ -196,6 +525,7 @@ param(
             if ($UnresolvedAttachmentUrls.Count -gt 0) {
                 [pscustomobject]@{
                     Status                   = 'unresolved'
+                    ObjectType               = 'article'
                     ArticleId                = $Article.id
                     ArticleName              = $Article.name
                     Reason                   = 'attachment URLs found but no AttachmentUrlMap match'
@@ -207,6 +537,7 @@ param(
 
             [pscustomobject]@{
                 Status       = 'clean'
+                ObjectType   = 'article'
                 ArticleId    = $Article.id
                 ArticleName  = $Article.name
                 Reason       = 'no attachment URLs found'
@@ -232,6 +563,7 @@ param(
 
             [pscustomobject]@{
                 Status       = if ($WhatIfPreference) { 'whatif' } else { 'replaced' }
+                ObjectType   = 'article'
                 ArticleId    = $Article.id
                 ArticleName  = $Article.name
                 Replacements = $Updated.Replacements
@@ -241,6 +573,7 @@ param(
         catch {
             [pscustomobject]@{
                 Status       = 'failed'
+                ObjectType   = 'article'
                 ArticleId    = $Article.id
                 ArticleName  = $Article.name
                 Error        = $_.Exception.Message
@@ -248,6 +581,9 @@ param(
             }
         }
     }
+
+    $AssetResults = Update-HuduAssetFieldsWithAttachmentUrlMap -Assets $Assets -UrlMap $UrlMap -AssetLayouts $AssetLayouts -WhatIf:$WhatIfPreference
+    $Results = @($ArticleResults) + @($AssetResults)
 
     $Results | ConvertTo-Json -Depth 100 | Out-File $OutputPath -WhatIf:$false
     return $Results

--- a/Public/ReplaceAttachmentLinks.ps1
+++ b/Public/ReplaceAttachmentLinks.ps1
@@ -363,6 +363,7 @@ param(
             $FieldLabel = $FieldEntry.Label
             $FieldKey = $FieldEntry.Key
             if ([string]::IsNullOrWhiteSpace($FieldKey)) { continue }
+            if ([string]::IsNullOrWhiteSpace($FieldLabel)) { continue }
 
             $FieldValue = $FieldEntry.Value
             if (Test-HuduAssetFieldIsRichText -Asset $Asset -Field $Field -AssetLayouts $AssetLayouts -AssetLayoutCache $AssetLayoutCache) {
@@ -371,7 +372,7 @@ param(
                 if ($Updated.Changed) {
                     Write-Host "Replacing $($Updated.Replacements.Count) attachment URL set(s) in asset '$($Asset.name)' field '$FieldLabel'" -ForegroundColor Green
                     $FieldValue = $Updated.Content
-                    $CustomFields += @{ $FieldKey = $FieldValue }
+                    $CustomFields += @{ $FieldLabel = $FieldValue }
                     $AssetReplacements += foreach ($Replacement in $Updated.Replacements) {
                         [pscustomobject]@{
                             FieldName      = $FieldLabel

--- a/Public/ReplaceAttachmentLinks.ps1
+++ b/Public/ReplaceAttachmentLinks.ps1
@@ -53,6 +53,10 @@ param(
                 $AttachmentId = $Matches.AttachmentId
                 $AttachmentPaths = @(
                     "/attachments/$AttachmentId"
+                    "/attachments/$AttachmentId`?edit"
+                    "/attachments/$AttachmentId`?edit=1"
+                    "/attachments/$AttachmentId`?edit=true"
+                    "/attachments/$AttachmentId`?preview"
                     "/attachments/$AttachmentId`?preview=1"
                     "/attachments/$AttachmentId`?preview=true"
                 )
@@ -66,6 +70,10 @@ param(
         elseif ($OriginalUrl -match '/(?:files|attachments)/(?<AttachmentId>\d{1,20})(?=$|[/?#])') {
             $AttachmentId = $Matches.AttachmentId
             $Candidates += "/attachments/$AttachmentId"
+            $Candidates += "/attachments/$AttachmentId`?edit"
+            $Candidates += "/attachments/$AttachmentId`?edit=1"
+            $Candidates += "/attachments/$AttachmentId`?edit=true"
+            $Candidates += "/attachments/$AttachmentId`?preview"
             $Candidates += "/attachments/$AttachmentId`?preview=1"
             $Candidates += "/attachments/$AttachmentId`?preview=true"
         }
@@ -97,7 +105,7 @@ param(
 )
     if ([string]::IsNullOrWhiteSpace($Content)) { return @() }
 
-    $AttachmentPattern = '(?:https?://[^"''\s<>]+)?/attachments/\d{1,20}(?:\?preview=(?:1|true))?'
+    $AttachmentPattern = '(?:https?://[^"''\s<>]+)?/attachments/\d{1,20}(?:\?(?:edit|preview)(?:=(?:1|true))?)?'
     @(
         [regex]::Matches($Content, $AttachmentPattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase) |
             ForEach-Object { $_.Value } |
@@ -166,38 +174,18 @@ param(
     (($Label -replace '[^\w\s]', '') -replace '\s+', '_').ToLower()
 }
 
-function Get-HuduAssetObject {
-param(
-    $Asset
-)
-    if ($Asset.HuduObject) { return $Asset.HuduObject }
-    return $Asset
-}
-
-function Get-HuduAssetFieldLabel {
-param(
-    $Field
-)
-    if ($Field -is [System.Collections.IDictionary] -and $Field.Keys.Count -eq 1) {
-        return [string]@($Field.Keys)[0]
-    }
-
-    $Properties = @($Field.PSObject.Properties | Where-Object { $_.MemberType -in 'NoteProperty','Property' })
-    if ($Properties.Count -eq 1) {
-        return [string]$Properties[0].Name
-    }
-
-    @(
-        $Field.label
-        $Field.caption
-        $Field.name
-    ) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -First 1
-}
-
 function Get-HuduAssetFieldEntry {
 param(
     $Field
 )
+    if ($Field.label) {
+        return [pscustomobject]@{
+            Label = $Field.label
+            Key   = ConvertTo-HuduAssetFieldKey -Label $Field.label
+            Value = $Field.value
+        }
+    }
+
     if ($Field -is [System.Collections.IDictionary] -and $Field.Keys.Count -eq 1) {
         $Key = [string]@($Field.Keys)[0]
         return [pscustomobject]@{
@@ -216,7 +204,7 @@ param(
         }
     }
 
-    $Label = Get-HuduAssetFieldLabel -Field $Field
+    $Label = $Field.label
     return [pscustomobject]@{
         Label = $Label
         Key   = ConvertTo-HuduAssetFieldKey -Label $Label
@@ -228,11 +216,7 @@ function Get-HuduAssetLayoutId {
 param(
     $Asset
 )
-    $LayoutId = $Asset.asset_layout_id
-    if (-not $LayoutId -and $Asset.asset_layout) {
-        $LayoutId = $Asset.asset_layout.id
-    }
-    return $LayoutId
+    return $Asset.asset_layout_id ?? $Asset.asset_layout.id
 }
 
 function Get-HuduAssetLayoutFields {
@@ -260,21 +244,19 @@ param(
         $Layout = $AssetLayouts | Where-Object {
             $_.id -eq $LayoutId -or $_.HuduID -eq $LayoutId -or $_.HuduObject.id -eq $LayoutId
         } | Select-Object -First 1
-        if ($Layout.HuduObject) { $Layout = $Layout.HuduObject }
-        if ($Layout.asset_layout) { $Layout = $Layout.asset_layout }
+        $Layout = $Layout.HuduObject ?? $Layout.asset_layout ?? $Layout
     }
 
     if (-not $Layout -and $MatchedLayouts) {
         $Layout = $MatchedLayouts | Where-Object {
             $_.id -eq $LayoutId -or $_.HuduID -eq $LayoutId -or $_.HuduObject.id -eq $LayoutId
         } | Select-Object -First 1
-        if ($Layout.HuduObject) { $Layout = $Layout.HuduObject }
-        if ($Layout.asset_layout) { $Layout = $Layout.asset_layout }
+        $Layout = $Layout.HuduObject ?? $Layout.asset_layout ?? $Layout
     }
 
     if (-not $Layout -and (Get-Command Get-HuduAssetLayouts -ErrorAction SilentlyContinue)) {
         $Layout = Get-HuduAssetLayouts -layoutid $LayoutId
-        if ($Layout.asset_layout) { $Layout = $Layout.asset_layout }
+        $Layout = $Layout.asset_layout ?? $Layout
     }
 
     if ($Layout -and $AssetLayoutCache) {
@@ -303,16 +285,13 @@ param(
         $Field.kind
     ) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
 
-    if ($FieldTypeValues | Where-Object { "$_" -ieq 'RichText' -or "$_" -ieq 'Textbox' }) {
-        return $true
+    if ($FieldTypeValues) {
+        return [bool]($FieldTypeValues | Where-Object { "$_" -ieq 'RichText' -or "$_" -ieq 'Textbox' })
     }
 
     $LayoutFields = Get-HuduAssetLayoutFields -Asset $Asset -AssetLayouts $AssetLayouts -AssetLayoutCache $AssetLayoutCache
     foreach ($LayoutField in $LayoutFields) {
-        $LayoutFieldLabel = $LayoutField.label
-        if ([string]::IsNullOrWhiteSpace($LayoutFieldLabel)) { $LayoutFieldLabel = $LayoutField.name }
-        if ([string]::IsNullOrWhiteSpace($LayoutFieldLabel)) { $LayoutFieldLabel = $LayoutField.caption }
-        $LayoutFieldKey = ConvertTo-HuduAssetFieldKey -Label $LayoutFieldLabel
+        $LayoutFieldKey = ConvertTo-HuduAssetFieldKey -Label $LayoutField.label
         if ($LayoutFieldKey -eq $FieldKey) {
             return ($LayoutField.field_type -ieq 'RichText')
         }
@@ -343,7 +322,7 @@ param(
 
 function Get-HuduAssetsForAttachmentLinkReplacement {
     if ($MatchedAssets) {
-        return @($MatchedAssets | ForEach-Object { Get-HuduAssetObject -Asset $_ } | Where-Object { $_ })
+        return @($MatchedAssets | ForEach-Object { $_.HuduObject ?? $_.asset ?? $_ } | Where-Object { $_ })
     }
 
     if (Get-Command Get-HuduAssets -ErrorAction SilentlyContinue) {
@@ -362,7 +341,7 @@ param(
 )
     $AssetLayoutCache = @{}
     $Results = foreach ($AssetInput in $Assets) {
-        $Asset = Get-HuduAssetObject -Asset $AssetInput
+        $Asset = $AssetInput.HuduObject ?? $AssetInput.asset ?? $AssetInput
         if (-not $Asset -or -not $Asset.fields) {
             [pscustomobject]@{
                 Status       = 'skipped'
@@ -444,15 +423,8 @@ param(
         try {
             $UpdatedAsset = $null
             if ($PSCmdlet.ShouldProcess("Asset $($Asset.id) '$($Asset.name)'", "replace attachment links in rich text fields")) {
-                $AssetPost = Invoke-HuduRequest -Method PUT -Resource "api/v1/companies/$($Asset.company_id)/assets/$($Asset.id)" -Body @{
-                    name            = $Asset.name
-                    asset_layout_id = Get-HuduAssetLayoutId -Asset $Asset
-                    custom_fields   = $CustomFields
-                } -ErrorAction Stop
-                $UpdatedAsset = $AssetPost.asset
-                if (-not $UpdatedAsset) {
-                    $UpdatedAsset = $AssetPost
-                }
+                $UpdatedAssetResponse = Set-HuduAsset -asset_id $Asset.id -name $Asset.name -company_id $Asset.company_id -asset_layout_id (Get-HuduAssetLayoutId -Asset $Asset) -fields $CustomFields -ErrorAction Stop
+                $UpdatedAsset = $UpdatedAssetResponse.asset ?? $UpdatedAssetResponse
             }
 
             [pscustomobject]@{

--- a/Public/ReplaceAttachmentLinks.ps1
+++ b/Public/ReplaceAttachmentLinks.ps1
@@ -371,6 +371,7 @@ param(
                 if ($Updated.Changed) {
                     Write-Host "Replacing $($Updated.Replacements.Count) attachment URL set(s) in asset '$($Asset.name)' field '$FieldLabel'" -ForegroundColor Green
                     $FieldValue = $Updated.Content
+                    $CustomFields += @{ $FieldKey = $FieldValue }
                     $AssetReplacements += foreach ($Replacement in $Updated.Replacements) {
                         [pscustomobject]@{
                             FieldName      = $FieldLabel
@@ -391,8 +392,6 @@ param(
                         }
                 }
             }
-
-            $CustomFields += @{ $FieldKey = $FieldValue }
         }
 
         if ($AssetReplacements.Count -lt 1) {

--- a/Public/Start-ArticleStubs.ps1
+++ b/Public/Start-ArticleStubs.ps1
@@ -14,6 +14,7 @@ function Start-ArticleStubs {
         [switch]$PlaceInternalDocsInInternalCompany
     )
     $doc = $Document
+    
 
     Write-Host "Starting $($doc.name)" -ForegroundColor Green
 

--- a/Public/Start-ITGlueToHuduURLRewrite.ps1
+++ b/Public/Start-ITGlueToHuduURLRewrite.ps1
@@ -1,5 +1,10 @@
 function Start-ITGlueToHuduURLRewrite {
 
+$MigrationLogMountScript = Join-Path $PSScriptRoot '..\Private\Mount-HuduMigrationLogs.ps1'
+if (Test-Path -LiteralPath $MigrationLogMountScript) {
+    . $MigrationLogMountScript
+}
+
 $UpdateArticles = (Get-HuduArticles | Where-Object {$_.content -like "*$ITGURL*"})
 $UpdateAssets = $MatchedAssets | Where-Object {$_.HuduObject -and $_.HuduObject.fields}
 $UpdatePasswords = $MatchedPasswords | Where-Object {$_.HuduObject.description -like "*$ITGURL*"}

--- a/Public/Start-ITGlueToHuduURLRewrite.ps1
+++ b/Public/Start-ITGlueToHuduURLRewrite.ps1
@@ -53,27 +53,20 @@ foreach ($assetFound in $UpdateAssets.HuduObject) {
                 Write-Host "Replacing Asset $($assetFound.name) field $($FieldEntry.Label) with updated content" -ForegroundColor 'Red'
                 $customFields += @{ $label = $NewContent }
                 $replacedStatus = 'replaced'
-            } else {
-                $customFields += @{ $label = $FieldValue }
             }
-        } else {
-            $customFields += @{ $label = $FieldValue }
         }
     }
 
     if ($replacedStatus -eq 'replaced') {
         Write-Host "Updating Asset $($assetFound.name) with new custom_fields array" -ForegroundColor 'Green'
-        $AssetPost = Invoke-HuduRequest -Method PUT -Resource "api/v1/companies/$($assetFound.company_id)/assets/$($assetFound.id)" -Body @{
-            name              = $assetFound.name
-            asset_layout_id   = $assetFound.asset_layout_id
-            custom_fields     = $customFields
-        }
+        $AssetPost = set-huduasset -companyId $assetFound.company_id -ID $assetFound.id -fields @($customFields)
+        $assetPost = $assetPost.asset ?? $assetPost   
     }
 
     $assetsUpdated += @{
         status         = $replacedStatus
         original_asset = $originalAsset
-        updated_asset  = $AssetPost.asset
+        updated_asset  = $AssetPost
     }
 }
 $assetsUpdated | ConvertTo-Json -depth 100 |Out-file "$MigrationLogs\ReplacedAssetsURL.json"

--- a/Public/Start-ITGlueToHuduURLRewrite.ps1
+++ b/Public/Start-ITGlueToHuduURLRewrite.ps1
@@ -34,6 +34,7 @@ $assetsUpdated = @()
 $AssetLayoutCache = @{}
 foreach ($assetFound in $UpdateAssets.HuduObject) {
     $originalAsset = $assetFound
+    $AssetPost = $null
     $replacedStatus = 'clean'
     $customFields = @()
 
@@ -58,7 +59,7 @@ foreach ($assetFound in $UpdateAssets.HuduObject) {
     }
 
     if ($replacedStatus -eq 'replaced') {
-        Write-Host "Updating Asset $($assetFound.name) with new custom_fields array" -ForegroundColor 'Green'
+        Write-Host "Updating Asset $($assetFound.name) with changed rich text field(s)" -ForegroundColor 'Green'
         $AssetPost = set-huduasset -companyId $assetFound.company_id -ID $assetFound.id -fields @($customFields)
         $assetPost = $assetPost.asset ?? $assetPost   
     }

--- a/Public/Start-ITGlueToHuduURLRewrite.ps1
+++ b/Public/Start-ITGlueToHuduURLRewrite.ps1
@@ -1,7 +1,7 @@
 function Start-ITGlueToHuduURLRewrite {
 
 $UpdateArticles = (Get-HuduArticles | Where-Object {$_.content -like "*$ITGURL*"})
-$UpdateAssets = $MatchedAssets | Where-Object {$_.HuduObject.fields.value -like "*$ITGURL*"}
+$UpdateAssets = $MatchedAssets | Where-Object {$_.HuduObject -and $_.HuduObject.fields}
 $UpdatePasswords = $MatchedPasswords | Where-Object {$_.HuduObject.description -like "*$ITGURL*"}
 $UpdateAssetPasswords = $MatchedAssetPasswords | Where-Object {$_.ITGObject.attributes.notes -like "*$ITGURL*"}
 $UpdateCompanyNotes = $MatchedCompanies | Where-Object {$_.HuduCompanyObject.notes -like "*$ITGURL*"}
@@ -31,28 +31,33 @@ Write-TimedMessage -Timeout 3 -Message "Snapshot Point: Article URLs Replaced. C
 
 # Assets
 $assetsUpdated = @()
+$AssetLayoutCache = @{}
 foreach ($assetFound in $UpdateAssets.HuduObject) {
+    $originalAsset = $assetFound
     $replacedStatus = 'clean'
     $customFields = @()
 
     foreach ($field in $assetFound.fields) {
-        # Convert the caption to snake_case to match API expectations for 2.37.1
-        $label = ($field.caption -replace '[^\w\s]', '') -replace '\s+', '_' | ForEach-Object { $_.ToLower() }
+        $FieldEntry = Get-HuduAssetFieldEntry -Field $field
+        $label = $FieldEntry.Key
+        $FieldValue = $FieldEntry.Value
+        if ([string]::IsNullOrWhiteSpace($label)) { continue }
 
-        if ($label -in @('itglue_url', 'itglue_id', 'imported_from_itglue') -and $field.value -like "*$ITGURL*") {
-            $NewContent = Update-StringWithCaptureGroups -inputString $field.value -pattern $RichRegexPatternToMatchSansAssets -type "rich"
+        if (Test-HuduAssetFieldIsRichText -Asset $assetFound -Field $field -AssetLayoutCache $AssetLayoutCache) {
+            $NewContent = Update-StringWithCaptureGroups -inputString "$FieldValue" -pattern $RichRegexPatternToMatchSansAssets -type "rich"
             $NewContent = Update-StringWithCaptureGroups -inputString $NewContent -pattern $RichRegexPatternToMatchWithAssets -type "rich"
+            $NewContent = Update-StringWithCaptureGroups -inputString $NewContent -pattern $RichDocLocatorUrlPatternToMatch -type "rich"
+            $NewContent = Update-StringWithCaptureGroups -inputString $NewContent -pattern $RichDocLocatorRelativeURLPatternToMatch -type "rich"
 
-            if ($NewContent -and $NewContent -ne $field.value) {
-                Write-Host "Replacing Asset $($assetFound.name) field $($field.caption) with updated content" -ForegroundColor 'Red'
+            if ($NewContent -and $NewContent -ne $FieldValue) {
+                Write-Host "Replacing Asset $($assetFound.name) field $($FieldEntry.Label) with updated content" -ForegroundColor 'Red'
                 $customFields += @{ $label = $NewContent }
                 $replacedStatus = 'replaced'
             } else {
-                $customFields += @{ $label = $field.value }
+                $customFields += @{ $label = $FieldValue }
             }
         } else {
-            # For other fields, preserve existing value (optional)
-            $customFields += @{ $label = $field.value }
+            $customFields += @{ $label = $FieldValue }
         }
     }
 

--- a/Public/Start-ITGlueToHuduURLRewrite.ps1
+++ b/Public/Start-ITGlueToHuduURLRewrite.ps1
@@ -40,9 +40,10 @@ foreach ($assetFound in $UpdateAssets.HuduObject) {
 
     foreach ($field in $assetFound.fields) {
         $FieldEntry = Get-HuduAssetFieldEntry -Field $field
-        $label = $FieldEntry.Key
+        $label = $FieldEntry.Label
         $FieldValue = $FieldEntry.Value
         if ([string]::IsNullOrWhiteSpace($label)) { continue }
+        if ([string]::IsNullOrWhiteSpace([string]$FieldValue)) { continue }
 
         if (Test-HuduAssetFieldIsRichText -Asset $assetFound -Field $field -AssetLayoutCache $AssetLayoutCache) {
             $NewContent = Update-StringWithCaptureGroups -inputString "$FieldValue" -pattern $RichRegexPatternToMatchSansAssets -type "rich"


### PR DESCRIPTION
improving the initial to-asset, to-config, to-contact, to-website link-replacements using the usual Update-StringWithCaptureGroups method that was always used

furthermore, improving the replacement of attachment links (since attachments happen so late in the process) to replace links in richtext/heading/embed fields for assets from migration

everything appears to be doing nicely so far, including attachment image src / anchor from other companies and other asset types (within scope)