### PR TITLE
Add progress logging to silent migration API loops

### DIFF
--- a/Add-HuduAttachmentsViaAPI.ps1
+++ b/Add-HuduAttachmentsViaAPI.ps1
@@ -287,8 +287,10 @@ param(
     # $UploadedAttachments = $ExistingAttachments | Select-Object @{n='id'; e={ $_.uploadable_id}},@{n='file';e={($_.file_data|Convertfrom-json).metadata.filename}},@{n='url';e={($_.file_data|Convertfrom-json).id}}
     ##### Replace above lines with new method that doesn't require database. Also commenting lines 149 and 150, 155-158
     
+    $__atIdx = 0; $__atTotal = @($FoundAssetsToAttach).count
     $Results = foreach ($FoundAsset in $FoundAssetsToAttach) {
-        Write-Host "Finding attachments for $($FoundAsset.name) with ITGlueID $($FoundAsset.itgid) to Hudu $($UploadType) $($FoundAsset.HuduID)" -ForegroundColor Cyan
+        $__atIdx++
+        Write-Host "Finding attachments for $($FoundAsset.name) with ITGlueID $($FoundAsset.itgid) to Hudu $($UploadType) $($FoundAsset.HuduID) (asset $__atIdx of $__atTotal)" -ForegroundColor Cyan
         # Write-Host "Checking existing attachments from database"
         # $CurrentAssetAttachments = $UploadedAttachments | Where-Object {$_.id -eq $FoundAsset.HuduID}
         

--- a/Get-MissingRelations.ps1
+++ b/Get-MissingRelations.ps1
@@ -726,23 +726,42 @@ foreach ($DiagnosticFileName in @('unknown-relation-types.json', 'unresolved-rel
 }
 
 write-host "refreshing $($MatchedAssets.count) assets"
-$FreshITGAssets= $FreshITGAssets ?? $($MatchedAssets |ForEach-Object { Get-ITGlueFlexibleAssets -id $_.ITGObject.id -include related_items})
+$__asIdx = 0; $__asTotal = $MatchedAssets.count
+$FreshITGAssets= $FreshITGAssets ?? $($MatchedAssets |ForEach-Object {
+    $__asIdx++
+    if ($__asIdx % 100 -eq 0 -or $__asIdx -eq $__asTotal) { Write-Host "  ...refreshed $__asIdx of $__asTotal assets" }
+    Get-ITGlueFlexibleAssets -id $_.ITGObject.id -include related_items})
 $RelatedAssets = $RelatedAssets ?? $($FreshITGAssets | Where-Object { Test-ITGlueResponseHasRelationData -Response $_ })
 
 write-host "refreshing $($MatchedConfigurations.count) configs"
-$FreshConfigurations = $FreshConfigurations ?? $($MatchedConfigurations | ForEach-Object {Get-ITGlueConfigurations -id $_.itgobject.id -include related_items})
+$__cfgIdx = 0; $__cfgTotal = $MatchedConfigurations.count
+$FreshConfigurations = $FreshConfigurations ?? $($MatchedConfigurations | ForEach-Object {
+    $__cfgIdx++
+    if ($__cfgIdx % 100 -eq 0 -or $__cfgIdx -eq $__cfgTotal) { Write-Host "  ...refreshed $__cfgIdx of $__cfgTotal configs" }
+    Get-ITGlueConfigurations -id $_.itgobject.id -include related_items})
 $RelatedConfigurations = $RelatedConfigurations ?? $($FreshConfigurations | Where-Object { Test-ITGlueResponseHasRelationData -Response $_ })
 
 write-host "refreshing $($MatchedPasswords.count) passwords"
-$FreshPasswords = $FreshPasswords ?? $($MatchedPasswords | ForEach-Object {Get-ITGluePasswords -id $_.itgobject.id -include related_items})
+$__pwIdx = 0; $__pwTotal = $MatchedPasswords.count
+$FreshPasswords = $FreshPasswords ?? $($MatchedPasswords | ForEach-Object {
+    $__pwIdx++
+    if ($__pwIdx % 100 -eq 0 -or $__pwIdx -eq $__pwTotal) { Write-Host "  ...refreshed $__pwIdx of $__pwTotal passwords" }
+    Get-ITGluePasswords -id $_.itgobject.id -include related_items})
 $RelatedPasswords = $RelatedPasswords ?? $($FreshPasswords | Where-Object { Test-ITGlueResponseHasRelationData -Response $_ })
 
 write-host "refreshing $($MatchedContacts.count) contacts"
-$FreshContacts = $FreshContacts ?? $($MatchedContacts | ForEach-Object {Get-ITGlueContacts -id $_.ITGObject.id -include related_items})
+$__ctIdx = 0; $__ctTotal = $MatchedContacts.count
+$FreshContacts = $FreshContacts ?? $($MatchedContacts | ForEach-Object {
+    $__ctIdx++
+    if ($__ctIdx % 100 -eq 0 -or $__ctIdx -eq $__ctTotal) { Write-Host "  ...refreshed $__ctIdx of $__ctTotal contacts" }
+    Get-ITGlueContacts -id $_.ITGObject.id -include related_items})
 $RelatedContacts = $RelatedContacts ?? $($FreshContacts | Where-Object { Test-ITGlueResponseHasRelationData -Response $_ })
 
 write-host "refreshing $($MatchedArticles.count) articles"
+$__arIdx = 0; $__arTotal = $MatchedArticles.count
 $FreshDocuments = $FreshDocuments ?? ($MatchedArticles | ForEach-Object {
+    $__arIdx++
+    if ($__arIdx % 100 -eq 0 -or $__arIdx -eq $__arTotal) { Write-Host "  ...refreshed $__arIdx of $__arTotal articles" }
     $ArticleLookup = Get-ArticleLookupInfo -Article $_
     if ($ArticleLookup) {
         Get-RelatedToDoc -DocID $ArticleLookup.DocID -OrganizationId $ArticleLookup.OrganizationId -ITGKey $ITGKey -ITGlue_Base_URI $settings.ITGAPIEndpoint
@@ -843,8 +862,11 @@ $AllRelationsToCreate =
 
 if (get-command -name Set-HapiErrorsDirectory -ErrorAction SilentlyContinue){try {Set-HapiErrorsDirectory -skipRetry $true} catch {}}
 write-host "Creating approximately $($AllRelationsToCreate.count) relations"
+$__relIdx = 0; $__relTotal = $AllRelationsToCreate.count
 $NewRelationsCreated = @(
     $AllRelationsToCreate | ForEach-Object {
+        $__relIdx++
+        if ($__relIdx % 100 -eq 0 -or $__relIdx -eq $__relTotal) { Write-Host "  ...creating relation $__relIdx of $__relTotal" }
         New-HuduRelation -FromableType $_.FromableType -FromableID $_.FromableID -ToableType $_.ToableType -ToableID $_.ToableID
     }
 )


### PR DESCRIPTION
Ran a migration on a large tenant and it sat on `refreshing 5290 passwords` for over an hour with no output. Turns out it was fine - just grinding through thousands of rate-limited ITGlue calls - but there's no way to tell that from a hung run because these loops only print a header and then go silent. The GUI's activity panel gets stuck on whatever the last line was too (in my case it was still showing the attachments "Press CTRL+C to cancel" countdown long after that step had finished).

This adds "X of N" progress lines to the loops that do the slow API work:

- `Get-MissingRelations.ps1` - the assets/configs/passwords/contacts/articles refresh loops and the relation-creation loop, printed every 100 items (plus the last one).
- `Add-HuduAttachmentsViaAPI.ps1` - a running "asset X of N" on the upload loop.

They're all `Write-Host`, so they only hit the console/log and don't get captured into the pipeline output - the refreshed/created object counts are exactly the same as before. Both files parse clean. The release `.exe` isn't included.
