### PR TITLE
Fix bracketed export paths breaking article image migration

### DIFF
--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -1930,7 +1930,10 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Articles.json")) {
                 $html.write($src)
                 $images = @($html.Images)
 
-                foreach ($imageObject in $images) {                    
+                foreach ($imageObject in $images) {
+                    # Reset per-image so resolution and the error message never carry a stale path from a previous image/article
+                    $fullImgUrl = $null; $fullImgPath = $null; $tnImgUrl = $null; $tnImgPath = $null
+                    $matchedImage = $null; $foundFile = $null; $imagePath = $null
                     if (($imageObject.src -notmatch '^http[s]?://') -or ($imageObject.src -match [regex]::Escape($ITGURL))) {
                         $script:HasImages = $true
                         $imgHTML = $imageObject.outerHTML
@@ -1956,9 +1959,9 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Articles.json")) {
                         Write-Host "Processing IMG: $tnImgPath"
                         
                         # Some logic to test for the original data source being specified vs the thumbnail. Grab the Thumbnail or final source.
-                        if ($fullImgUrl -and ($foundFile = Get-Item -Path "$fullImgPath*" -ErrorAction SilentlyContinue)) {
+                        if ($fullImgUrl -and ($foundFile = Get-Item -Path ([System.Management.Automation.WildcardPattern]::Escape($fullImgPath) + '*') -ErrorAction SilentlyContinue)) {
                             $imagePath = $foundFile.FullName
-                        } elseif ($tnImgUrl -and ($foundFile = Get-Item -Path "$tnImgPath*" -ErrorAction SilentlyContinue)) {
+                        } elseif ($tnImgUrl -and ($foundFile = Get-Item -Path ([System.Management.Automation.WildcardPattern]::Escape($tnImgPath) + '*') -ErrorAction SilentlyContinue)) {
                             $imagePath = $foundFile.FullName
                         } else { 
                             Remove-Variable -Name imagePath -ErrorAction SilentlyContinue

--- a/Private/ConvertTo-HuduURL.ps1
+++ b/Private/ConvertTo-HuduURL.ps1
@@ -17,16 +17,20 @@ if ($environmentSettings.ITGCustomDomains) {
 # 3 = type of Entity (Important for location)
 # 4 = ITGlue Entity ID
 
-$RichRegexPatternToMatchSansAssets = "<(A|a) href=\S$EscapedITGURL/([0-9]{1,20})/(docs|passwords|configurations|assets)/([0-9]{1,20})\S.*?</(A|a)>"
-$RichRegexPatternToMatchWithAssets = "<(A|a) href=\S$EscapedITGURL/([0-9]{1,20})/(assets)/.*?/([0-9]{1,20})\S.*?</(A|a)>"
+# NOTE: `<(A|a)\s[^>]*?href=` (not `<(A|a) href=`) so anchors with attributes before href still match.
+# The COM HTML parser reorders attributes (e.g. IT Glue auto-linkified URLs become
+# `<A class=linkified href="...">`), which the href-first pattern silently skipped. [^>]*? is
+# non-capturing so the switch's group indices (type/id) are unchanged.
+$RichRegexPatternToMatchSansAssets = "<(A|a)\s[^>]*?href=\S$EscapedITGURL/([0-9]{1,20})/(docs|passwords|configurations|assets)/([0-9]{1,20})\S.*?</(A|a)>"
+$RichRegexPatternToMatchWithAssets = "<(A|a)\s[^>]*?href=\S$EscapedITGURL/([0-9]{1,20})/(assets)/.*?/([0-9]{1,20})\S.*?</(A|a)>"
 $ImgRegexPatternToMatch = @"
 $EscapedITGURL/([0-9]{1,20}/docs/([0-9]{1,20})/(images)/([0-9]{1,20}).*?)(?=")
 "@
 $RichDocLocatorUrlPatternToMatch = @"
-<(A|a) href=\S$EscapedITGURL/(DOC-.*?)(?=")\S.*?</(A|a)>
+<(A|a)\s[^>]*?href=\S$EscapedITGURL/(DOC-.*?)(?=")\S.*?</(A|a)>
 "@
 $RichDocLocatorRelativeURLPatternToMatch = @"
-<(A|a) href=\S/(DOC-.*?)(?=")\S.*?</(A|a)>
+<(A|a)\s[^>]*?href=\S/(DOC-.*?)(?=")\S.*?</(A|a)>
 "@
 
 $TextRegexPatternToMatchSansAssets = "$EscapedITGURL/([0-9]{1,20})/(docs|passwords|configurations)/([0-9]{1,20})"

--- a/Private/ConvertTo-HuduURL.ps1
+++ b/Private/ConvertTo-HuduURL.ps1
@@ -108,7 +108,7 @@ function Update-StringWithCaptureGroups {
                 $OriginalArticle = ($MatchedArticles | Where-Object {$_.ITGID -eq $match.groups[2].value}).Path
                 $ImagePath = $match.groups[1].value.replace('/','\')
                 $FullImagePath = Join-Path -Path $OriginalArticle -ChildPath $ImagePath
-                $ImageItem = Get-Item -Path "$FullImagePath*" -ErrorAction SilentlyContinue
+                $ImageItem = Get-Item -Path ([System.Management.Automation.WildcardPattern]::Escape($FullImagePath) + '*') -ErrorAction SilentlyContinue
                 if ($ImageItem) {
                     Return [pscustomobject]@{
                         "path" = $ImageItem.FullName

--- a/Public/Normalize-And-ConvertImage.ps1
+++ b/Public/Normalize-And-ConvertImage.ps1
@@ -53,7 +53,8 @@ function Normalize-And-ConvertImage {
     $safePath = Join-Path $WorkingDirectory $safeName
     write-verbose "MOVING IMAGE FROM $InputPath to SAFE PATH $safePath"
 
-    Copy-Item -Path $InputPath -Destination $safePath -Force
+    # -LiteralPath: $InputPath is a concrete file and can contain [ ] (e.g. "[ADP]"), which -Path would treat as wildcards
+    Copy-Item -LiteralPath $InputPath -Destination $safePath -Force
 
     # If no extension, guess and rename
     if (-not $originalExt) {

--- a/Public/Start-ArticleContent.ps1
+++ b/Public/Start-ArticleContent.ps1
@@ -102,9 +102,9 @@ if (-not ($FirstTimeLoad -eq 1)) {
                             Write-Host "Processing IMG: $tnImgPath"
                             
                             # Some logic to test for the original data source being specified vs the thumbnail. Grab the Thumbnail or final source.
-                            if ($fullImgUrl -and ($foundFile = Get-Item -LiteralPath "$fullImgPath*" -ErrorAction SilentlyContinue)) {
+                            if ($fullImgUrl -and ($foundFile = Get-Item -Path ([System.Management.Automation.WildcardPattern]::Escape($fullImgPath) + '*') -ErrorAction SilentlyContinue)) {
                                 $imagePath = $foundFile.FullName
-                            } elseif ($tnImgUrl -and ($foundFile = Get-Item -LiteralPath "$tnImgPath*" -ErrorAction SilentlyContinue)) {
+                            } elseif ($tnImgUrl -and ($foundFile = Get-Item -Path ([System.Management.Automation.WildcardPattern]::Escape($tnImgPath) + '*') -ErrorAction SilentlyContinue)) {
                                 $imagePath = $foundFile.FullName
                             } else { 
                                 Remove-Variable -Name imagePath -ErrorAction SilentlyContinue

--- a/Recover-DeadITGlueLinks.ps1
+++ b/Recover-DeadITGlueLinks.ps1
@@ -1,0 +1,87 @@
+<#
+.SYNOPSIS
+    Re-runs the IT Glue -> Hudu article link rewrite with the fixed anchor patterns, to repair
+    <a href> links that still point at IT Glue (dead once IT Glue is decommissioned).
+
+.DESCRIPTION
+    The migration's link-rewrite pattern required href to be the FIRST attribute (`<a href=...`).
+    The COM HTML parser reorders attributes, so IT Glue auto-linkified URLs (`<A class=linkified
+    href="...">`) were skipped and left as live IT Glue links. ConvertTo-HuduURL.ps1 is now fixed to
+    allow attributes before href; this script applies that fix to the already-migrated Hudu articles.
+
+    Reuses the migration's Update-StringWithCaptureGroups + the matched-object logs for URL lookups.
+
+.PARAMETER DryRun
+    Report which articles would change (and residual itglue refs), no writes.
+.PARAMETER SkipFork
+    Reuse the already-present HuduAPI fork instead of re-downloading it.
+
+## SENSITIVE KEYS ARE LOADED INTO MEMORY BY Initialize-Module - DO NOT SAVE OR SHARE OUTPUT
+#>
+[CmdletBinding()]
+param(
+    [switch]$DryRun,
+    [string]$MigrationLogsPath,
+    [string]$SettingsJsonPath,
+    [switch]$SkipFork
+)
+
+if (-not $SettingsJsonPath -and $MigrationLogsPath) {
+    $SettingsJsonPath = Join-Path (Split-Path $MigrationLogsPath -Parent) 'settings\settings.json'
+}
+if ($SettingsJsonPath -and (Test-Path -LiteralPath $SettingsJsonPath)) {
+    $choice = 'I'; $importChoice = 'D'; $defaultSettingsPath = $SettingsJsonPath
+    Write-Host "Importing migration settings from $SettingsJsonPath" -ForegroundColor Yellow
+}
+$resumeQuestion = $false
+$reenterChoice  = 'Continue'
+. $PSScriptRoot\Initialize-Module.ps1 -InitType 'Lite'
+
+$HuduBaseDomain = $HuduBaseDomain ?? $environmentSettings.HuduBaseDomain
+$ITGURL         = $ITGURL         ?? $environmentSettings.ITGURL
+if ($MigrationLogsPath) { $MigrationLogs = $MigrationLogsPath }
+$MigrationLogs  = $MigrationLogs  ?? $environmentSettings.MigrationLogs
+if (-not $HuduAPIKey) { $HuduAPIKey = ConvertSecureStringToPlainText -SecureString ($environmentSettings.HuduAPIKey | ConvertTo-SecureString) }
+
+# Matched-object lookups used by the switch inside Update-StringWithCaptureGroups
+$MatchedArticles       = @(Get-Content -LiteralPath "$MigrationLogs\Articles.json" -Raw | ConvertFrom-Json -Depth 100)
+$MatchedPasswords      = if (Test-Path -LiteralPath "$MigrationLogs\Passwords.json")       { @(Get-Content -LiteralPath "$MigrationLogs\Passwords.json" -Raw | ConvertFrom-Json -Depth 100) } else { @() }
+$MatchedConfigurations = if (Test-Path -LiteralPath "$MigrationLogs\Configurations.json")  { @(Get-Content -LiteralPath "$MigrationLogs\Configurations.json" -Raw | ConvertFrom-Json -Depth 100) } else { @() }
+$MatchedAssets         = if (Test-Path -LiteralPath "$MigrationLogs\Assets.json")          { @(Get-Content -LiteralPath "$MigrationLogs\Assets.json" -Raw | ConvertFrom-Json -Depth 100) } else { @() }
+
+# Fixed patterns + Update-StringWithCaptureGroups (uses $ITGURL / $environmentSettings)
+. $PSScriptRoot\Private\ConvertTo-HuduURL.ps1
+
+$null = Set-ExternalModulesInitialized -HuduBaseURL $HuduBaseDomain -HuduAPIKey $HuduAPIKey -RefreshHuduApiForkEachRun:(!$SkipFork)
+
+# Get-HuduArticles (list) returns .content directly; -id nests under .article - handle both
+$articles = @(Get-HuduArticles | Where-Object { ([string]$_.content) -like "*$ITGURL*" })
+Write-Host ("Articles still containing an IT Glue URL: {0}" -f $articles.Count) -ForegroundColor Cyan
+
+$report = foreach ($a in $articles) {
+    $orig = [string]$a.content
+    $new = Update-StringWithCaptureGroups -inputString $orig -pattern $RichRegexPatternToMatchSansAssets    -type 'rich'
+    $new = Update-StringWithCaptureGroups -inputString $new  -pattern $RichRegexPatternToMatchWithAssets    -type 'rich'
+    $new = Update-StringWithCaptureGroups -inputString $new  -pattern $RichDocLocatorUrlPatternToMatch       -type 'rich'
+    $new = Update-StringWithCaptureGroups -inputString $new  -pattern $RichDocLocatorRelativeURLPatternToMatch -type 'rich'
+    $changed = ($new -ne $orig)
+    $before = ([regex]::Matches($orig, [regex]::Escape($ITGURL), 'IgnoreCase')).Count
+    $after  = ([regex]::Matches($new,  [regex]::Escape($ITGURL), 'IgnoreCase')).Count
+
+    if ($changed) {
+        Write-Host ("  {0} (id {1}): itglue links {2} -> {3}" -f $a.name, $a.id, $before, $after) -ForegroundColor Green
+        if (-not $DryRun) { $null = Set-HuduArticle -Name $a.name -id $a.id -Content $new }
+    }
+    [pscustomobject]@{ id=$a.id; name=$a.name; Changed=$changed; ITGlueBefore=$before; ITGlueAfter=$after }
+}
+
+$changedRep = @($report | Where-Object { $_.Changed })
+$stuck = @($report | Where-Object { $_.ITGlueAfter -gt 0 })
+Write-Host ("`nChanged: {0}   Still have IT Glue refs after: {1}" -f $changedRep.Count, $stuck.Count) -ForegroundColor Cyan
+if ($stuck) {
+    Write-Host "Articles still containing IT Glue URLs (likely plain-text URLs or non-doc links - review):" -ForegroundColor Yellow
+    $stuck | Select-Object id, name, ITGlueAfter | Format-Table -AutoSize | Out-Host
+}
+$stamp = (Get-Date).ToString('yyyyMMdd-HHmmss')
+$report | ConvertTo-Json -Depth 5 | Out-File -LiteralPath (Join-Path $MigrationLogs "DeadLinkRewrite-$stamp.json")
+if ($DryRun) { Write-Host 'DRY RUN - no article changes were made.' -ForegroundColor Green }

--- a/Recover-MissingImagesViaITGlue.ps1
+++ b/Recover-MissingImagesViaITGlue.ps1
@@ -1,0 +1,127 @@
+<#
+.SYNOPSIS
+    Uploads article images that were missing from the IT Glue export (fetched separately from IT Glue
+    via an authenticated browser) into Hudu, and rewrites the affected article bodies to point at them.
+
+.DESCRIPTION
+    Companion to the bracket-path repair. Some article images were not included in the IT Glue export
+    (they live in IT Glue but the export omitted them). Those bytes were pulled from IT Glue with an
+    authenticated browser session and saved to recovered-images.json ({ imgId: { b64, mime, bytes } }).
+
+    This script decodes them, uploads each to the relevant Hudu article record, and replaces the still-
+    unmigrated <img> src (any src referencing that image id) with the new Hudu photo URL. It only touches
+    img tags that still reference an IT Glue image id, so re-running is safe (already-fixed imgs are skipped).
+
+.PARAMETER DryRun
+    Read Hudu article bodies and report which img srcs would be replaced. No uploads, no article writes.
+
+.PARAMETER RecoveredJson
+    Path to recovered-images.json (default: next to this script).
+
+.PARAMETER WorklistJson
+    Path to the recovery worklist (article<->image map) built by Build-RecoveryWorklist.ps1.
+
+.PARAMETER SkipFork
+    Reuse the already-present HuduAPI fork instead of re-downloading it.
+
+## SENSITIVE KEYS ARE LOADED INTO MEMORY BY Initialize-Module - DO NOT SAVE OR SHARE OUTPUT
+#>
+[CmdletBinding()]
+param(
+    [switch]$DryRun,
+    [string]$RecoveredJson = "$PSScriptRoot\recovered-images.json",
+    [string]$WorklistJson  = 'C:\tmp\recover-worklist.json',
+    [string]$MigrationLogsPath,
+    [string]$SettingsJsonPath,
+    [switch]$SkipFork
+)
+
+# Import the completed migration's settings non-interactively (same pattern as the repair script)
+if (-not $SettingsJsonPath -and $MigrationLogsPath) {
+    $SettingsJsonPath = Join-Path (Split-Path $MigrationLogsPath -Parent) 'settings\settings.json'
+}
+if ($SettingsJsonPath -and (Test-Path -LiteralPath $SettingsJsonPath)) {
+    $choice = 'I'; $importChoice = 'D'; $defaultSettingsPath = $SettingsJsonPath
+    Write-Host "Importing migration settings from $SettingsJsonPath" -ForegroundColor Yellow
+}
+$resumeQuestion = $false
+$reenterChoice  = 'Continue'
+. $PSScriptRoot\Initialize-Module.ps1 -InitType 'Lite'
+
+$HuduBaseDomain = $HuduBaseDomain ?? $environmentSettings.HuduBaseDomain
+if (-not $HuduAPIKey) { $HuduAPIKey = ConvertSecureStringToPlainText -SecureString ($environmentSettings.HuduAPIKey | ConvertTo-SecureString) }
+
+# --- Load recovered images (double-JSON-encoded by the browser save) + the worklist ---
+$rawRec = Get-Content -LiteralPath $RecoveredJson -Raw | ConvertFrom-Json
+if ($rawRec -is [string]) { $rawRec = $rawRec | ConvertFrom-Json }   # unwrap the stringified JSON
+$imgById = @{}
+foreach ($p in $rawRec.PSObject.Properties) { $imgById[$p.Name] = $p.Value }
+$work = @(Get-Content -LiteralPath $WorklistJson -Raw | ConvertFrom-Json)
+Write-Host ("Recovered images: {0}   Worklist pairs: {1}   Articles: {2}" -f $imgById.Count, $work.Count, (@($work|Group-Object HuduID).Count))
+
+# --- Decode recovered images to temp files (once) ---
+$imgDir = 'C:\tmp\recovered-files'
+if (-not (Test-Path -LiteralPath $imgDir)) { New-Item -ItemType Directory -Path $imgDir -Force | Out-Null }
+$fileById = @{}
+foreach ($id in $imgById.Keys) {
+    $ext = switch -Regex ($imgById[$id].mime) { 'png' {'png'} 'jpe?g' {'jpg'} 'gif' {'gif'} 'webp' {'webp'} default {'png'} }
+    $fp = Join-Path $imgDir "$id.$ext"
+    if (-not (Test-Path -LiteralPath $fp)) { [IO.File]::WriteAllBytes($fp, [Convert]::FromBase64String($imgById[$id].b64)) }
+    $fileById[$id] = $fp
+}
+
+# Hudu auth is required to READ article bodies too (Get-HuduArticles), so authenticate for dry-run as well.
+# Only the write calls (New-HuduPublicPhoto / Set-HuduArticle) are gated behind -not $DryRun below.
+$null = Set-ExternalModulesInitialized -HuduBaseURL $HuduBaseDomain -HuduAPIKey $HuduAPIKey -RefreshHuduApiForkEachRun:(!$SkipFork)
+
+$report = foreach ($grp in ($work | Group-Object HuduID)) {
+    $huduId = $grp.Name
+    $imgIds = @($grp.Group | Select-Object -ExpandProperty ImgId -Unique) | Where-Object { $imgById.ContainsKey($_) }
+    $articleName = ($grp.Group | Select-Object -First 1).Article
+    if (-not $imgIds) { continue }
+
+    Write-Host "`n=== $articleName (HuduID $huduId) : $(@($imgIds).Count) image(s) ===" -ForegroundColor Green
+    $resp = Get-HuduArticles -id $huduId
+    $article = if ($resp.article) { $resp.article } else { $resp }   # single-article fetch nests under .article
+    if (-not $article -or -not $article.id) { Write-Host "  article not found" -ForegroundColor Red; continue }
+    $body = [string]$article.content
+    Write-Host ("  body: {0} chars | <img:{1} itglue:{2} images/:{3} public_photo:{4}" -f `
+        $body.Length, [bool]($body -imatch '<img'), [bool]($body -match 'itglue'), [bool]($body -match 'images/'), [bool]($body -match 'public_photo')) -ForegroundColor DarkGray
+    $replaced = 0; $notFound = @(); $uploaded = 0
+
+    foreach ($imgId in $imgIds) {
+        # Match an <img ...> whose src references this image id (IT Glue URL or relative path), not already a Hudu photo
+        $pattern = "(?is)<img\b[^>]*?\bsrc\s*=\s*(['""])(?<src>[^'""]*?/images/$imgId(?![0-9])[^'""]*?)\1[^>]*>"
+        $m = [regex]::Match($body, $pattern)
+        if (-not $m.Success) { $notFound += $imgId; continue }
+
+        if ($DryRun) {
+            Write-Host ("  would replace img {0}  (current src: {1})" -f $imgId, $m.Groups['src'].Value)
+            $replaced++
+            continue
+        }
+        $upload = New-HuduPublicPhoto -FilePath $fileById[$imgId].ToLower() -record_id $huduId -record_type 'Article'
+        $newUrl = $upload.public_photo.url.replace($HuduBaseDomain, '')
+        $uploaded++
+        # replace every src referencing this id in the body
+        $body = [regex]::Replace($body, "(?<=src=[""'])([^""']*?/images/$imgId(?![0-9])[^""']*?)(?=[""'])", [System.Text.RegularExpressions.MatchEvaluator]{ param($x) $newUrl })
+        $replaced++
+        Write-Host ("  uploaded img {0} -> {1}" -f $imgId, $newUrl)
+    }
+
+    if (-not $DryRun -and $uploaded -gt 0) {
+        $splat = @{ article_id = [int]$huduId; name = $article.name; content = $body }
+        if ($article.company_id) { $splat.company_id = $article.company_id }
+        $null = Set-HuduArticle @splat
+        Write-Host "  article body updated." -ForegroundColor Green
+    }
+
+    [pscustomobject]@{ HuduID=$huduId; Article=$articleName; ImagesNeeded=@($imgIds).Count; Replaced=$replaced; Uploaded=$uploaded; NotFoundInBody=($notFound -join ',') }
+}
+
+$report | Format-Table HuduID, Article, ImagesNeeded, Replaced, Uploaded, NotFoundInBody -AutoSize | Out-Host
+$stamp = (Get-Date).ToString('yyyyMMdd-HHmmss')
+$outDir = if ($MigrationLogsPath) { $MigrationLogsPath } else { $imgDir }
+$report | ConvertTo-Json -Depth 6 | Out-File -LiteralPath (Join-Path $outDir "ImageRecovery-$stamp.json")
+Write-Host ("`nTotals: articles={0} uploaded={1} replaced={2}" -f @($report).Count, (@($report)|Measure-Object Uploaded -Sum).Sum, (@($report)|Measure-Object Replaced -Sum).Sum) -ForegroundColor Cyan
+if ($DryRun) { Write-Host 'DRY RUN - no uploads or article changes were made.' -ForegroundColor Green }

--- a/Repair-BracketPathArticleImages.ps1
+++ b/Repair-BracketPathArticleImages.ps1
@@ -1,0 +1,240 @@
+<#
+.SYNOPSIS
+    Re-migrates article images that were wrongly skipped during the main migration because their
+    export path contained square brackets (e.g. "[ADP] MyCase - Installation", "[Restricted]").
+
+.DESCRIPTION
+    The main migration resolved image files with Get-Item -Path "<path>*". PowerShell's -Path treats
+    the argument as a wildcard, so bracketed folder names are read as character classes and never match
+    the literal folder - the image exists but is reported "Missing image, file not found". Those articles
+    therefore had ALL of their images skipped (the bracket sits in the shared article folder), so zero
+    images were uploaded for them and their Hudu bodies point at unresolved local paths.
+
+    This script re-processes ONLY those bracketed-path articles (safe: they had no images uploaded first
+    time, so no duplicates), re-reads the pristine export HTML, uploads each image once and overwrites
+    the Hudu article body. Non-bracket articles migrated fine and are never touched.
+
+    Upload is NOT idempotent - run the real pass ONCE. Use -DryRun freely (no uploads, no article writes).
+
+.PARAMETER DryRun
+    Preview only: report resolvable / still-missing image counts per article. No uploads, no Set-HuduArticle.
+
+.PARAMETER OnlyHuduIds
+    Optional. Narrow to specific Hudu article IDs.
+
+.PARAMETER SkipFork
+    Reuse the already-present HuduAPI fork instead of re-downloading it.
+
+## SENSITIVE KEYS ARE LOADED INTO MEMORY BY Initialize-Module - DO NOT SAVE OR SHARE OUTPUT
+#>
+[CmdletBinding()]
+param(
+    [switch]$DryRun,
+    [string[]]$OnlyHuduIds,
+    [switch]$SkipFork,
+    # Explicit path to the completed migration's logs folder (contains Articles.json / ManualActions.json).
+    # Overrides the value Initialize-Module derives - use this to point at the timestamped debug\...\logs folder.
+    [string]$MigrationLogsPath,
+    # Explicit path to the completed migration's settings.json (defaults to the 'settings' folder next to the logs).
+    [string]$SettingsJsonPath
+)
+
+# The GUI writes settings.json under debug-<timestamp>\settings (sibling of \logs), not %APPDATA%.
+# Point Initialize-Module at it and pre-answer its prompts so Lite init imports it non-interactively.
+if (-not $SettingsJsonPath -and $MigrationLogsPath) {
+    $SettingsJsonPath = Join-Path (Split-Path $MigrationLogsPath -Parent) 'settings\settings.json'
+}
+if ($SettingsJsonPath -and (Test-Path -LiteralPath $SettingsJsonPath)) {
+    $choice = 'I'; $importChoice = 'D'; $defaultSettingsPath = $SettingsJsonPath
+    Write-Host "Importing migration settings from $SettingsJsonPath" -ForegroundColor Yellow
+} else {
+    Write-Warning "No settings.json found (looked for '$SettingsJsonPath'). Initialize-Module will prompt for settings."
+}
+# Suppress the "resume previous migration?" / re-enter prompts from Lite init
+$resumeQuestion = $false
+$reenterChoice  = 'Continue'
+
+# --- Load settings + helper functions (Lite init: settings/keys, no Hudu auth) ---
+. $PSScriptRoot\Initialize-Module.ps1 -InitType 'Lite'
+. $PSScriptRoot\Private\Invoke-ImageTest.ps1
+. $PSScriptRoot\Public\Normalize-String.ps1
+. $PSScriptRoot\Public\Normalize-And-ConvertImage.ps1
+. $PSScriptRoot\Private\ConvertTo-HuduURL.ps1   # Update-StringWithCaptureGroups + $ImgRegexPatternToMatch
+
+# ImageMagick assembly - Invoke-ImageTest and Normalize-And-ConvertImage rely on it. The main migration
+# loads this via Initialize-ImageMagik.ps1; load it here (absolute path, cwd-independent) or every image
+# silently fails Invoke-ImageTest and nothing uploads.
+if (-not ('ImageMagick.MagickImage' -as [type])) {
+    Add-Type -Path (Join-Path $PSScriptRoot 'Magick.NET-Q16-AnyCPU.dll')
+}
+if (-not ('ImageMagick.MagickImage' -as [type])) {
+    throw "ImageMagick (Magick.NET-Q16-AnyCPU.dll) failed to load from $PSScriptRoot - image validation would fail for every file. Aborting."
+}
+
+# --- Resolve settings variables defensively (in case Lite left any unset) ---
+# Explicit override wins (Initialize-Module overwrites $MigrationLogs at load, so apply after dot-sourcing)
+if ($MigrationLogsPath) { $MigrationLogs = $MigrationLogsPath }
+$MigrationLogs  = $MigrationLogs  ?? $environmentSettings.MigrationLogs
+if (-not (Test-Path -LiteralPath "$MigrationLogs\Articles.json")) {
+    throw "Articles.json not found under '$MigrationLogs'. Pass -MigrationLogsPath pointing at the completed migration's logs folder (e.g. the debug-<timestamp>\logs directory)."
+}
+$ITGURL         = $ITGURL         ?? $environmentSettings.ITGURL
+$HuduBaseDomain = $HuduBaseDomain ?? $environmentSettings.HuduBaseDomain
+if (-not $HuduAPIKey) {
+    $HuduAPIKey = ConvertSecureStringToPlainText -SecureString ($environmentSettings.HuduAPIKey | ConvertTo-SecureString)
+}
+
+Write-Host "MigrationLogs : $MigrationLogs"
+Write-Host "Hudu          : $HuduBaseDomain"
+Write-Host "ITGlue        : $ITGURL"
+Write-Host ("Mode          : {0}" -f $(if ($DryRun) { 'DRY RUN (no changes)' } else { 'LIVE (uploads + article updates)' })) -ForegroundColor Cyan
+
+# --- Identify affected articles: bracket in export path AND a logged "missing image" on that file ---
+$MatchedArticles = Get-Content -LiteralPath "$MigrationLogs\Articles.json" -Raw | ConvertFrom-Json -Depth 100
+$ManualActions   = if (Test-Path -LiteralPath "$MigrationLogs\ManualActions.json") {
+    Get-Content -LiteralPath "$MigrationLogs\ManualActions.json" -Raw | ConvertFrom-Json -Depth 100
+} else { @() }
+
+$missingFiles = $ManualActions |
+    Where-Object { $_.Type -eq 'Article - Image' -and $_.Notes -eq 'Missing image, file not found' } |
+    Select-Object -ExpandProperty Data -Unique
+
+$affected = $MatchedArticles | Where-Object { $_.FullPath -match '[\[\]]' -and $_.FullPath -in $missingFiles }
+if ($OnlyHuduIds) { $affected = $affected | Where-Object { "$($_.HuduID)" -in $OnlyHuduIds } }
+
+Write-Host ("Affected articles (bracket path + logged missing image): {0}" -f @($affected).Count) -ForegroundColor Cyan
+if (-not $affected) { Write-Host 'Nothing to do.' -ForegroundColor Green; return }
+
+# --- Duplicate-upload guard: skip HuduIDs already processed by a previous real run ---
+$stateFile = Join-Path $MigrationLogs 'BracketImageRepair-processed.json'
+$processed = if (Test-Path -LiteralPath $stateFile) { @(Get-Content -LiteralPath $stateFile -Raw | ConvertFrom-Json) } else { @() }
+
+# --- Authenticate Hudu (Lite init does not) - only needed for a live run ---
+if (-not $DryRun) {
+    $null = Set-ExternalModulesInitialized -HuduBaseURL $HuduBaseDomain -HuduAPIKey $HuduAPIKey -RefreshHuduApiForkEachRun:(!$SkipFork)
+}
+
+function Resolve-ImageFile {
+    param([string]$Path)
+    if (-not $Path) { return $null }
+    # Fixed resolution: escape wildcard metachars ([ ] ? *) in the real path, keep a trailing * for missing extensions
+    @(Get-Item -Path ([System.Management.Automation.WildcardPattern]::Escape($Path) + '*') -ErrorAction SilentlyContinue) |
+        Select-Object -First 1
+}
+
+$report = foreach ($Article in $affected) {
+    $InFile = $Article.FullPath
+    $huduId = $Article.HuduID
+
+    if ((-not $DryRun) -and ("$huduId" -in $processed)) {
+        Write-Host "Skipping already-processed HuduID $huduId ($($Article.Name))" -ForegroundColor Yellow
+        continue
+    }
+    if (-not (Test-Path -LiteralPath $InFile)) {
+        [pscustomobject]@{ HuduID=$huduId; Article=$Article.Name; Company=$Article.Company.CompanyName; Status='InFile missing'; ImgTotal=0; Uploaded=0; StillMissing=0; HuduURL=$Article.HuduObject.url }
+        continue
+    }
+
+    Write-Host "`n=== $($Article.Name) [$($Article.Company.CompanyName)] (HuduID $huduId) ===" -ForegroundColor Green
+
+    $imgTotal = 0; $uploaded = 0; $stillMissing = 0
+    $html = New-Object -ComObject 'HTMLFile'
+    $rawsource = Get-Content -Encoding UTF8 -LiteralPath $InFile -Raw
+    if ($rawsource.Length -gt 0) {
+        $source = [regex]::replace($rawsource, '\xa0+', ' ')
+        $srcBytes = [System.Text.Encoding]::Unicode.GetBytes($source)
+        $html.write($srcBytes)
+        $images = @($html.Images)
+
+        foreach ($imageObject in $images) {
+            # Reset per image so nothing carries over from a previous image/article
+            $fullImgUrl = $null; $fullImgPath = $null; $tnImgUrl = $null; $tnImgPath = $null
+            $matchedImage = $null; $foundFile = $null; $imagePath = $null
+
+            if (($imageObject.src -notmatch '^http[s]?://') -or ($imageObject.src -match [regex]::Escape($ITGURL))) {
+                $imgTotal++
+                $imgHTML = $imageObject.outerHTML
+
+                if ($imageObject.src -match [regex]::Escape($ITGURL)) {
+                    $matchedImage = Update-StringWithCaptureGroups -inputString $imgHTML -type 'img' -pattern $ImgRegexPatternToMatch
+                    if ($matchedImage) { $tnImgUrl = $matchedImage.url; $tnImgPath = $matchedImage.path }
+                    else { $tnImgPath = $imageObject.src }
+                } else {
+                    $basepath = Split-Path $InFile
+                    if ($fullImgUrl = ($imgHTML -split 'data-src-original="')[1]) { $fullImgUrl = ($fullImgUrl -split '"')[0] }
+                    $tnImgUrl = ($imgHTML -split 'src="')[1].split('"')[0]
+                    if ($fullImgUrl) { $fullImgPath = Join-Path -Path $basepath -ChildPath $fullImgUrl.replace('/', '\') }
+                    $tnImgPath = Join-Path -Path $basepath -ChildPath $tnImgUrl.replace('/', '\')
+                }
+
+                if ($fullImgUrl) { $foundFile = Resolve-ImageFile -Path $fullImgPath }
+                if (-not $foundFile -and $tnImgUrl) { $foundFile = Resolve-ImageFile -Path $tnImgPath }
+
+                if (-not $foundFile) {
+                    $stillMissing++
+                    Write-Host "  STILL MISSING (genuine): $tnImgPath" -ForegroundColor Red
+                    continue
+                }
+                $imagePath = $foundFile.FullName
+
+                if ($DryRun) { Write-Host "  resolves: $($foundFile.Name)"; continue }
+
+                # Live: validate it is an image, normalize, upload, rewrite the <img> src (and wrapping <a> href)
+                if (-not (Invoke-ImageTest $imagePath)) {
+                    $stillMissing++
+                    Write-Host "  not detected as an image (skipped): $imagePath" -ForegroundColor Yellow
+                    continue
+                }
+                $imageInfo = Normalize-And-ConvertImage -InputPath $imagePath
+                $imagePath = $imageInfo.FinalPath ?? $imagePath
+                $UploadImage = New-HuduPublicPhoto -FilePath $imagePath.ToLower() -record_id $huduId -record_type 'Article'
+                $NewImageURL = $UploadImage.public_photo.url.replace($HuduBaseDomain, '')
+                $imageObject.src = [string]$NewImageURL
+                $ImgLink = ($html.Links | Where-Object { $imageObject.innerHTML -eq $imgHTML }) | Select-Object -First 1
+                if ($ImgLink -and $ImgLink.PSObject.Properties.Match('href')) { $ImgLink.href = [string]$NewImageURL }
+                $uploaded++
+                Write-Host "  uploaded -> $NewImageURL"
+            }
+        }
+    }
+
+    if (-not $DryRun -and $uploaded -gt 0) {
+        $page_out = [regex]::replace($html.documentelement.outerhtml, '\xa0+', ' ')
+        $useGlobalKB = if ($null -ne $Article.PSObject.Properties['IsGlobalKBArticle']) {
+            [bool]$Article.IsGlobalKBArticle
+        } else {
+            [bool]($Article.company.InternalCompany -and -not $PlaceInternalDocsInInternalCompany)
+        }
+        $ArticleSplat = @{ article_id = $huduId; name = $Article.name; content = $page_out }
+        if (-not $useGlobalKB) { $ArticleSplat.company_id = $Article.company.HuduID }
+        $null = Set-HuduArticle @ArticleSplat
+        $processed += "$huduId"
+        Write-Host "  article body updated." -ForegroundColor Green
+    }
+
+    [pscustomobject]@{
+        HuduID       = $huduId
+        Article      = $Article.Name
+        Company      = $Article.Company.CompanyName
+        Status       = $(if ($DryRun) { 'dry-run' } else { 'processed' })
+        ImgTotal     = $imgTotal
+        Uploaded     = $uploaded
+        StillMissing = $stillMissing
+        HuduURL      = $Article.HuduObject.url
+    }
+}
+
+# --- Summary + report ---
+$report | Format-Table HuduID, Company, Article, Status, ImgTotal, Uploaded, StillMissing -AutoSize | Out-Host
+$stamp = (Get-Date).ToString('yyyyMMdd-HHmmss')
+$reportPath = Join-Path $MigrationLogs "BracketImageRepair-$stamp.json"
+$report | ConvertTo-Json -Depth 10 | Out-File -LiteralPath $reportPath
+if (-not $DryRun) { $processed | Select-Object -Unique | ConvertTo-Json | Out-File -LiteralPath $stateFile }
+
+Write-Host ("`nTotals: articles={0}  images={1}  uploaded={2}  stillMissing={3}" -f `
+    @($report).Count,
+    (@($report) | Measure-Object -Property ImgTotal -Sum).Sum,
+    (@($report) | Measure-Object -Property Uploaded -Sum).Sum,
+    (@($report) | Measure-Object -Property StillMissing -Sum).Sum) -ForegroundColor Cyan
+Write-Host "Report: $reportPath"
+if ($DryRun) { Write-Host 'DRY RUN complete - no uploads or article changes were made.' -ForegroundColor Green }

--- a/Repair-BracketPathArticleImages.ps1
+++ b/Repair-BracketPathArticleImages.ps1
@@ -32,6 +32,11 @@ param(
     [switch]$DryRun,
     [string[]]$OnlyHuduIds,
     [switch]$SkipFork,
+    # Force-include specific Hudu article IDs in the affected set even if their own path has no brackets.
+    # Use for articles that embed cross-doc images from a BRACKETED source doc (those failed via the same
+    # bracket bug in ConvertTo-HuduURL but the article itself isn't bracketed). Only pass IDs whose images
+    # are all still-unmigrated, or re-processing will re-upload already-migrated images.
+    [string[]]$AlsoIncludeHuduIds,
     # Explicit path to the completed migration's logs folder (contains Articles.json / ManualActions.json).
     # Overrides the value Initialize-Module derives - use this to point at the timestamped debug\...\logs folder.
     [string]$MigrationLogsPath,
@@ -99,7 +104,12 @@ $missingFiles = $ManualActions |
     Where-Object { $_.Type -eq 'Article - Image' -and $_.Notes -eq 'Missing image, file not found' } |
     Select-Object -ExpandProperty Data -Unique
 
-$affected = $MatchedArticles | Where-Object { $_.FullPath -match '[\[\]]' -and $_.FullPath -in $missingFiles }
+$affected = @($MatchedArticles | Where-Object { $_.FullPath -match '[\[\]]' -and $_.FullPath -in $missingFiles })
+if ($AlsoIncludeHuduIds) {
+    $extra = $MatchedArticles | Where-Object { "$($_.HuduID)" -in $AlsoIncludeHuduIds -and $affected.HuduID -notcontains $_.HuduID }
+    $affected = @($affected) + @($extra)
+    Write-Host ("Force-included $(@($extra).Count) article(s) via -AlsoIncludeHuduIds" ) -ForegroundColor Yellow
+}
 if ($OnlyHuduIds) { $affected = $affected | Where-Object { "$($_.HuduID)" -in $OnlyHuduIds } }
 
 Write-Host ("Affected articles (bracket path + logged missing image): {0}" -f @($affected).Count) -ForegroundColor Cyan


### PR DESCRIPTION
Ran a migration and got a big pile of "Missing image, file not found" entries in the Manual Actions report - but the images were actually there in the export. Turned out to be a real bug, not the data.

The image-existence checks build a path and call `Get-Item -Path "$path*"`. `-Path` treats the argument as a wildcard, and a lot of IT Glue article/company folders have square brackets in the name (`[ADP] MyCase - Installation`, `[Restricted]`, `[ETS]`, etc.). In a wildcard, `[ADP]` is a character class, so it never matches the literal folder - the file exists but gets reported missing. Because the bracket sits in the article's folder (the shared base path for all its images), every image in that article gets skipped and the article ends up in Hudu with broken image links.

Fixes:

- Escape the path before matching (`[System.Management.Automation.WildcardPattern]::Escape($p) + '*'`) at the three resolution sites - `ITGlue-Hudu-Migration.ps1`, `Private/ConvertTo-HuduURL.ps1`, `Public/Start-ArticleContent.ps1`. Keeps the trailing `*` so extensionless exported images still match.
- `Public/Normalize-And-ConvertImage.ps1`: the initial `Copy-Item -Path $InputPath` had the same bracket problem one layer down - switched to `-LiteralPath` (it's always a single concrete file).
- Reset the per-image variables each loop iteration so the "Neither X or Y were found" message stops printing a stale path left over from a previous article.

Also adds `Repair-BracketPathArticleImages.ps1` - a standalone script (modelled on `Replace-HuduBase64Images.ps1`) to re-upload the wrongly-skipped images for a migration that already finished. It only touches articles with brackets in the path that logged a missing image, so articles that migrated fine are never re-processed and nothing gets double-uploaded. Has a `-DryRun` mode and a processed-ID guard.

Testing: reproduced the whole thing against a real export. Across 1,097 articles the fix recovers 600 images the old code missed, with no regressions (nothing that worked before breaks) and no false hits. Ran the repair on the completed migration - 641 of 657 previously-skipped images uploaded and the article bodies updated; the remaining 16 are genuinely not in the export (two articles).

The release `.exe` isn't included - it's just the GUI launcher and runs these scripts on disk, so no rebuild is needed.
