### PR TITLE
Fix/re align imageanchorreplacement

### DIFF
--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -2498,11 +2498,9 @@ foreach ($companyFound in $UpdateCompanyNotes.HuduCompanyObject) {
 $companyNotesUpdated | ConvertTo-Json -depth 100 |Out-file "$MigrationLogs\ReplacedCompaniesURL.json"
 Write-TimedMessage -Timeout 3 -Message "Snapshot Point: Company Notes URLs Replaced. Continue?"  -DefaultResponse "continue to Manual Actions, please."
 
-Write-Host "Replacing links to hosted public photos in Hudu Articles"
+Write-Host "Replacing hard-coded IT Glue image links in Hudu Articles"
 if (-not $(get-command -name Set-HuduImageAnchorsReplaced -ErrorAction SilentlyContinue)){. $PSScriptRoot\Public\Set-HuduImageAnchorsReplaced.ps1}
 . $PSScriptRoot\Public\Replace-HardCodedImages.ps1
-
-Get-AllHuduHostedImageAnchorsReplaced -allhuduArticles $(get-huduarticles)
 
 ############################### Wrap-Up ###############################
 
@@ -2514,6 +2512,9 @@ write-host "wrapup 2/10... adding attachments and replacing any found attachment
 . .\Add-HuduAttachmentsViaAPI.ps1
 Write-Host "Attachments - enumerating and replacing attachment links in articles"; $null = Start-MigrationJob -Name "Wrap-Up - Attachment Links";
 $replacedAttachmentURLs = Start-HuduAttachmentLinkReplacement
+Write-Host "Replacing hosted image-only anchors in Hudu Articles"
+$imageAnchorReplacementResults = Get-AllHuduHostedImageAnchorsReplaced -allhuduArticles $(Get-HuduArticles) -includeUploads $true
+$imageAnchorReplacementResults | ConvertTo-Json -Depth 100 | Out-File "$MigrationLogs\ReplacedImageAnchors.json"
 
 write-host "wrapup 3/10... Creating IPAM/Networks and Addresses if user-configured to do so... $($importChecklists)"
 if ($true -eq $ImportConfigInterfaces){

--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -581,6 +581,9 @@ foreach ($ITGL in $($MatchedLocations ?? @())) {
     $ITGLocationsHashTable["$($ITGL.itgid)"] = $ITGL
 }
 $LocationLayout = Get-HuduAssetLayouts -name $LocImportAssetLayoutName
+if ($null -ne $LocationLayout -and $null -ne $LocationLayout.id) {
+    try {set-huduassetlayout -id $LocationLayout.id -isLocation $true} catch {}
+}
 
 ############################### Websites ###############################
 

--- a/Public/Set-HuduImageAnchorsReplaced.ps1
+++ b/Public/Set-HuduImageAnchorsReplaced.ps1
@@ -21,19 +21,61 @@ function Set-HuduImageAnchorsReplaced {
         )
     }
 
-    # 1) Remove existing anchors that ONLY wrap an <img> tag
-    # <a ...><img ...></a>  ->  <img ...>
+    $isHuduHostedImage = {
+        param([string]$src)
+
+        foreach ($p in $serverPatterns) {
+            if ($src -match $p) {
+                return $true
+            }
+        }
+
+        return $false
+    }
+
+    $getFullImageUrl = {
+        param([string]$src)
+
+        if ($src -match '^https?://') {
+            return $src
+        }
+
+        if ($src.StartsWith('/')) {
+            return "$base$src"
+        }
+
+        return "$base/$src"
+    }
+
+    $imgPattern = '<img\b[^>]*\bsrc\s*=\s*["'']([^"'']+)["''][^>]*>'
+
+    # 1) Remove existing anchors that ONLY wrap one of our hosted <img> tags.
+    # <a ...><img src="/public_photo/..."></a>  ->  <img src="/public_photo/...">
+    # External image links are preserved.
     $noAnchors = [regex]::Replace(
         $Html,
         '<a\b[^>]*>\s*(<img\b[^>]*>)\s*</a>',
-        '$1',
+        {
+            param($match)
+
+            $imgTag = $match.Groups[1].Value
+            $imgMatch = [regex]::Match($imgTag, $imgPattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+            if (-not $imgMatch.Success) {
+                return $match.Value
+            }
+
+            $src = $imgMatch.Groups[1].Value
+            if (& $isHuduHostedImage $src) {
+                return $imgTag
+            }
+
+            return $match.Value
+        },
         [System.Text.RegularExpressions.RegexOptions]::IgnoreCase `
             -bor [System.Text.RegularExpressions.RegexOptions]::Singleline
     )
 
     # 2) Wrap qualifying <img> tags in <a href="fullsrc">
-    $imgPattern = '<img\b[^>]*\bsrc\s*=\s*["'']([^"'']+)["''][^>]*>'
-
     $result = [regex]::Replace(
         $noAnchors,
         $imgPattern,
@@ -44,30 +86,11 @@ function Set-HuduImageAnchorsReplaced {
             $src    = $match.Groups[1].Value
 
             # Only touch "our" images (public_photo / uploads)
-            $isOurImage = $false
-            foreach ($p in $serverPatterns) {
-                if ($src -match $p) {
-                    $isOurImage = $true
-                    break
-                }
-            }
-
-            if (-not $isOurImage) {
+            if (-not (& $isHuduHostedImage $src)) {
                 return $imgTag   # leave external images alone
             }
 
-            # Normalize to absolute URL
-            if ($src -match '^https?://') {
-                $full = $src
-            }
-            else {
-                if ($src.StartsWith('/')) {
-                    $full = "$base$src"
-                }
-                else {
-                    $full = "$base/$src"
-                }
-            }
+            $full = & $getFullImageUrl $src
 
             "<a href=""$full"">$imgTag</a>"
         },
@@ -78,9 +101,58 @@ function Set-HuduImageAnchorsReplaced {
 }
 
 function Get-AllHuduHostedImageAnchorsReplaced {
+    [CmdletBinding(SupportsShouldProcess)]
     param ([array]$allHuduArticles=@(),[bool]$includeUploads=$false)
-    foreach ($a in $allarticles) {
-    if ([string]::IsNullOrEmpty($a.content)){write-host "skipping $($a.id)"; continue;}
-        Set-HuduArticle -id $a.id -Content "$(Set-HuduImageAnchorsReplaced -Html $a.content -IncludeUploads $includeUploads)"
+
+    foreach ($a in @($allHuduArticles)) {
+        if ([string]::IsNullOrEmpty($a.content)) {
+            Write-Host "skipping $($a.id)"
+            [pscustomobject]@{
+                Status      = 'skipped'
+                ArticleId   = $a.id
+                ArticleName = $a.name
+                Reason      = 'empty content'
+            }
+            continue
+        }
+
+        $newContent = Set-HuduImageAnchorsReplaced -Html $a.content -IncludeUploads $includeUploads
+        if ($newContent -eq $a.content) {
+            [pscustomobject]@{
+                Status      = 'clean'
+                ArticleId   = $a.id
+                ArticleName = $a.name
+            }
+            continue
+        }
+
+        try {
+            $updatedArticle = $null
+            if ($PSCmdlet.ShouldProcess("Article $($a.id) '$($a.name)'", "replace hosted image anchors")) {
+                $setArticleSplat = @{
+                    Id      = $a.id
+                    Content = $newContent
+                }
+                if ($a.name) { $setArticleSplat.Name = $a.name }
+                if ($a.company_id) { $setArticleSplat.CompanyId = $a.company_id }
+
+                $updatedArticle = Set-HuduArticle @setArticleSplat -ErrorAction Stop
+            }
+
+            [pscustomobject]@{
+                Status         = if ($WhatIfPreference) { 'whatif' } else { 'replaced' }
+                ArticleId      = $a.id
+                ArticleName    = $a.name
+                UpdatedArticle = $updatedArticle
+            }
+        }
+        catch {
+            [pscustomobject]@{
+                Status      = 'failed'
+                ArticleId   = $a.id
+                ArticleName = $a.name
+                Error       = $_.Exception.Message
+            }
+        }
     }
 }


### PR DESCRIPTION
Just a quick re-alignment for image anchors
due to a few changes in link replacement and image path stuff, this needed to happen just a little bit later on. Tested with both relative and absolute image anchor paths.