### PR TITLE
Comprehensively rewrite IT Glue URLs in the migration + fix URL-script SwitchParameter error

### DIFF
--- a/Backfill-PasswordOTPSeeds.ps1
+++ b/Backfill-PasswordOTPSeeds.ps1
@@ -1,0 +1,144 @@
+<#
+.SYNOPSIS
+    Backfill TOTP/OTP seeds onto Hudu passwords that lost them during migration.
+
+.DESCRIPTION
+    The migration validated each IT Glue OTP seed and silently dropped any that wasn't pure base32 or
+    fell outside 16-80 chars (only a Write-Warning, no manual action), so some Hudu passwords have an
+    empty otp_secret while IT Glue held a valid seed. This audits the completed migration's Passwords
+    log, finds every password whose IT Glue seed is present but whose Hudu seed is empty, normalises the
+    seed (otpauth:// URIs, padding, display spaces, long-but-valid base32) via the shared
+    ConvertTo-NormalizedOtpSecret, and pushes it with Set-HuduPassword -OTPSecret. Seeds that are still
+    not valid base32 after normalisation are reported for manual confirmation - never guessed.
+
+    The Passwords.json log alone drives this (it carries HuduID + the original IT Glue seed), so no
+    re-run of the migration is required. Re-running is safe: only empty Hudu seeds are filled.
+
+.PARAMETER DryRun
+    Report which passwords WOULD be backfilled (and which need manual confirmation); no writes.
+.PARAMETER MigrationLogsPath
+    Path to the completed migration's \logs folder (contains Passwords.json).
+.PARAMETER SettingsJsonPath
+    Path to settings.json (defaults to <MigrationLogsParent>\settings\settings.json).
+.PARAMETER SkipFork
+    Reuse the already-present HuduAPI fork instead of re-downloading it.
+
+## SENSITIVE KEYS ARE LOADED INTO MEMORY BY Initialize-Module - DO NOT SAVE OR SHARE OUTPUT
+#>
+[CmdletBinding()]
+param(
+    [switch]$DryRun,
+    [string]$MigrationLogsPath,
+    [string]$SettingsJsonPath,
+    [switch]$SkipFork
+)
+
+# --- Non-interactive settings import (same pattern as the other remediation scripts) ---
+if (-not $SettingsJsonPath -and $MigrationLogsPath) {
+    $SettingsJsonPath = Join-Path (Split-Path $MigrationLogsPath -Parent) 'settings\settings.json'
+}
+if ($SettingsJsonPath -and (Test-Path -LiteralPath $SettingsJsonPath)) {
+    $choice = 'I'; $importChoice = 'D'; $defaultSettingsPath = $SettingsJsonPath
+    Write-Host "Importing migration settings from $SettingsJsonPath" -ForegroundColor Yellow
+}
+$resumeQuestion = $false
+$reenterChoice  = 'Continue'
+. $PSScriptRoot\Initialize-Module.ps1 -InitType 'Lite'
+. $PSScriptRoot\Private\ConvertTo-NormalizedOtpSecret.ps1
+
+$HuduBaseDomain = $HuduBaseDomain ?? $environmentSettings.HuduBaseDomain
+if ($MigrationLogsPath) { $MigrationLogs = $MigrationLogsPath }
+$MigrationLogs  = $MigrationLogs ?? $environmentSettings.MigrationLogs
+if (-not $HuduAPIKey) { $HuduAPIKey = ConvertSecureStringToPlainText -SecureString ($environmentSettings.HuduAPIKey | ConvertTo-SecureString) }
+
+# Hudu auth is required to WRITE seeds (and to re-read for confirmation). Reads are needed for dry-run too.
+$null = Set-ExternalModulesInitialized -HuduBaseURL $HuduBaseDomain -HuduAPIKey $HuduAPIKey -RefreshHuduApiForkEachRun:(!$SkipFork)
+
+# --- Load the migrated password records (standalone + asset-embedded) ---
+function Import-PwLog($file) {
+    $p = "$MigrationLogs\$file"
+    if ((Test-Path -LiteralPath $p) -and (Get-Item -LiteralPath $p).Length -gt 0) {
+        @(Get-Content -LiteralPath $p -Raw | ConvertFrom-Json -Depth 100)
+    } else { @() }
+}
+$records = @(Import-PwLog 'Passwords.json') + @(Import-PwLog 'AssetPasswords.json')
+Write-Host ("Loaded {0} password records" -f $records.Count) -ForegroundColor Cyan
+
+# Suggest an obvious base32 transcription fix for reporting (never auto-applied): 1->I, 0->O, 8->B.
+function Get-Base32Suggestion($raw) {
+    if ([string]::IsNullOrWhiteSpace($raw)) { return $null }
+    $try = ((($raw.Trim().ToUpperInvariant()) -replace '\s','') -replace '=+$','') `
+        -replace '1','I' -replace '0','O' -replace '8','B'
+    if ($try -match '^[A-Z2-7]+$' -and $try.Length -ge 16) { return $try } else { return $null }
+}
+
+$fixed = [System.Collections.Generic.List[object]]::new()
+$needsConfirm = [System.Collections.Generic.List[object]]::new()
+$alreadyOk = 0; $noItgSeed = 0; $failed = 0
+
+foreach ($p in $records) {
+    $srcRaw = [string]$p.ITGObject.attributes.otp_secret
+    if ([string]::IsNullOrWhiteSpace($srcRaw)) { $noItgSeed++; continue }      # nothing to migrate
+    $huduSeed = [string]$p.HuduObject.otp_secret
+    if (-not [string]::IsNullOrWhiteSpace($huduSeed)) { $alreadyOk++; continue } # Hudu already has a seed
+
+    # IT Glue had a seed, Hudu is empty -> a drop. Try to normalise it.
+    $hid  = if ($p.HuduObject.id) { $p.HuduObject.id } else { $p.HuduID }
+    $name = [string]$p.Name
+    $url  = [string]$p.HuduObject.url
+    $norm = ConvertTo-NormalizedOtpSecret $srcRaw
+
+    if (-not $norm) {
+        $needsConfirm.Add([pscustomobject]@{
+            Name = $name; HuduID = $hid; Hudu_URL = $url
+            RawSeedPreview = if ($srcRaw.Length -gt 60) { $srcRaw.Substring(0,60) + '...' } else { $srcRaw }
+            Suggestion = Get-Base32Suggestion $srcRaw
+            Note = 'IT Glue seed is not valid base32 after normalisation - confirm the correct seed before pushing.'
+        })
+        continue
+    }
+
+    if ($DryRun) {
+        $fixed.Add([pscustomobject]@{ Name=$name; HuduID=$hid; Hudu_URL=$url; SeedLength=$norm.Length; Status='would-backfill' })
+        continue
+    }
+
+    try {
+        $upd = Set-HuduPassword -Id $hid -OTPSecret $norm
+        $landed = [string]$upd.asset_password.otp_secret
+        if (-not [string]::IsNullOrWhiteSpace($landed)) {
+            $fixed.Add([pscustomobject]@{ Name=$name; HuduID=$hid; Hudu_URL=$url; SeedLength=$norm.Length; Status='backfilled' })
+            Write-Host ("  backfilled OTP for {0} (id {1})" -f $name, $hid) -ForegroundColor Green
+        } else {
+            $failed++
+            $needsConfirm.Add([pscustomobject]@{ Name=$name; HuduID=$hid; Hudu_URL=$url; RawSeedPreview=''; Suggestion=$null
+                Note = "Push returned an empty otp_secret - Hudu may have rejected the seed (length $($norm.Length)?). Verify manually." })
+            Write-Host ("  WARNING: seed did not stick for {0} (id {1})" -f $name, $hid) -ForegroundColor Red
+        }
+    } catch {
+        $failed++
+        Write-Warning ("  failed to set OTP for {0} (id {1}): {2}" -f $name, $hid, $_)
+    }
+}
+
+# --- Report ---
+Write-Host ("`nPasswords with an IT Glue seed already in Hudu: {0}" -f $alreadyOk) -ForegroundColor DarkGray
+Write-Host ("$(if($DryRun){'Would backfill'}else{'Backfilled'}): {0}   Need manual confirmation: {1}   Failed: {2}" -f $fixed.Count, $needsConfirm.Count, $failed) -ForegroundColor Cyan
+
+if ($fixed.Count) {
+    Write-Host "`n--- Verify each of these against your authenticator (name -> Hudu URL) ---" -ForegroundColor Yellow
+    $fixed | ForEach-Object { Write-Host ("  {0,-45} {1}" -f $_.Name, $_.Hudu_URL) }
+}
+if ($needsConfirm.Count) {
+    Write-Host "`n--- Need manual confirmation (NOT changed) ---" -ForegroundColor Yellow
+    $needsConfirm | ForEach-Object {
+        Write-Host ("  {0,-45} {1}" -f $_.Name, $_.Hudu_URL)
+        if ($_.Suggestion) { Write-Host ("      likely-correct seed: {0}" -f $_.Suggestion) -ForegroundColor DarkYellow }
+    }
+}
+
+$stamp = (Get-Date).ToString('yyyyMMdd-HHmmss')
+[pscustomobject]@{ Fixed=$fixed; NeedsConfirmation=$needsConfirm; AlreadyOk=$alreadyOk; Failed=$failed; DryRun=[bool]$DryRun } |
+    ConvertTo-Json -Depth 6 | Out-File -LiteralPath (Join-Path $MigrationLogs "OTPSeedBackfill-$stamp.json")
+Write-Host ("`nReport: {0}" -f (Join-Path $MigrationLogs "OTPSeedBackfill-$stamp.json"))
+if ($DryRun) { Write-Host 'DRY RUN - no passwords were changed.' -ForegroundColor Green }

--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -53,6 +53,7 @@ $FontAwesomeUpgrade = Get-FontAwesomeMap
 # Add Replace URL functions
 . $PSScriptRoot\Private\ConvertTo-HuduURL.ps1
 . $PSScriptRoot\Private\Update-AllITGlueUrls.ps1   # comprehensive all-type/plain-text URL rewriter
+. $PSScriptRoot\Private\ConvertTo-NormalizedOtpSecret.ps1   # normalise/validate TOTP seeds (no silent drops)
 
 # Add Hudu Relations Function
 . $PSScriptRoot\Public\Add-HuduRelation.ps1
@@ -2297,16 +2298,15 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Passwords.json")) {
 					
                     if (!($($unmatchedPassword.ITGObject.attributes."resource-type") -eq "flexible-asset-traits")) {
 
-                        $validated_otp = "$($unmatchedPassword.ITGObject.attributes.otp_secret)".Trim().ToUpper()
-                        if ($validated_otp) {
-                            $isValidBase32 = $validated_otp -match '^[A-Z2-7]+$'
-                            $lengthOK = $validated_otp.Length -ge 16 -and $validated_otp.Length -le 80
-
-                            $validated_otp = if ($isValidBase32 -and $lengthOK) { $validated_otp } else { $null }
-
-                            if (-not ($isValidBase32 -and $lengthOK)) {
-                                Write-Warning "Invalid OTP secret for $($unmatchedPassword.ITGObject.attributes.name): $($unmatchedPassword.ITGObject.attributes.otp_secret)... valid base32? $isValidBase32 length ok? $lengthOK (min / max is 16 / 80 chars)"
-                            }                            
+                        # Normalise the IT Glue seed (otpauth:// URIs, '=' padding, display spaces, and
+                        # long-but-valid base32 that the old 16-80 char cap wrongly rejected) via the
+                        # shared helper. $otpDropped flags a seed that WAS present but is unusable, so it
+                        # is surfaced as a manual action after the password is created rather than lost.
+                        $srcOtp = "$($unmatchedPassword.ITGObject.attributes.otp_secret)"
+                        $validated_otp = ConvertTo-NormalizedOtpSecret $srcOtp
+                        $otpDropped = (-not [string]::IsNullOrWhiteSpace($srcOtp)) -and (-not $validated_otp)
+                        if ($otpDropped) {
+                            Write-Warning "OTP secret for $($unmatchedPassword.ITGObject.attributes.name) is not usable base32 after normalisation; flagging as a manual action."
                         }
 
 
@@ -2355,6 +2355,17 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Passwords.json")) {
                         $unmatchedPassword.Imported = "Created-By-Script"
                         $ImportsMigrated = $ImportsMigrated + 1
                         Write-host "$($HuduNewPassword.Name) Has been created in Hudu"
+                        if ($otpDropped) {
+                            $manualActions.add([PSCustomObject]@{
+                                name       = "$($unmatchedPassword.ITGObject.attributes.name)"
+                                company_id = $company.HuduCompanyObject.ID
+                                Type       = "Password - OTP"
+                                Hudu_URL   = $HuduNewPassword.url
+                                ITG_URL    = if ($url = $unmatchedPassword.ITGObject.attributes.url) {$url} Else {$unmatchedPassword.ITGObject.attributes.'resource-url'}
+                                otpsecret  = "removed for security purposes"
+                                problem    = "OTP seed present in IT Glue but not valid base32 after normalisation; confirm and set the seed manually."
+                            })
+                        }
                         
                     }
                 }

--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -52,6 +52,7 @@ $FontAwesomeUpgrade = Get-FontAwesomeMap
 
 # Add Replace URL functions
 . $PSScriptRoot\Private\ConvertTo-HuduURL.ps1
+. $PSScriptRoot\Private\Update-AllITGlueUrls.ps1   # comprehensive all-type/plain-text URL rewriter
 
 # Add Hudu Relations Function
 . $PSScriptRoot\Public\Add-HuduRelation.ps1
@@ -2380,29 +2381,57 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Passwords.json")) {
 
 $null = Start-MigrationJob -Name "LinkReplacement"
 
-$UpdateArticles = (Get-HuduArticles | Where-Object {$_.content -like "*$ITGURL*"})
-$UpdateAssets = $MatchedAssets | Where-Object {$_.HuduObject.fields.value -like "*$ITGURL*"}
-$UpdatePasswords = $MatchedPasswords | Where-Object {$_.HuduObject.description -like "*$ITGURL*"}
-$UpdateAssetPasswords = $MatchedAssetPasswords | Where-Object {$_.ITGObject.attributes.notes -like "*$ITGURL*"}
-$UpdateCompanyNotes = $MatchedCompanies | Where-Object {$_.HuduCompanyObject.notes -like "*$ITGURL*"}
+# Build comprehensive ITGlue-id -> Hudu-url maps once, for the all-type / plain-text rewriter
+# (Update-AllITGlueUrls). It runs alongside the original anchor-only rewriter so EVERY IT Glue URL
+# form - plain text as well as anchors, encoded wrappers, kb.itglue.com, and every entity type
+# (docs/passwords/configurations/assets/contacts/locations/websites) - is repointed to Hudu. Links to
+# items that were NOT migrated (deleted in IT Glue, index/list pages) are left in place and collected
+# in $itgDeadLinks for the manual-actions report.
+$ItgDomain = ($ITGURL -replace '^https?://', '').TrimEnd('/')
+$itgUrlMaps = Get-ITGlueUrlMaps -HuduBaseDomain $HuduBaseDomain -Articles $MatchedArticles `
+    -Passwords $MatchedPasswords -AssetPasswords $MatchedAssetPasswords -Configurations $MatchedConfigurations `
+    -Assets $MatchedAssets -Contacts $MatchedContacts -Locations $MatchedLocations -Websites $MatchedWebsites
+$itgDeadLinks = [System.Collections.Generic.List[object]]::new()
+
+# Filters widened from -like "*$ITGURL*" to -match 'itglue\.com' so kb.itglue.com, encoded and other
+# host forms are caught too (articles are enumerated from the full matched set below, not the list
+# endpoint, because that endpoint can silently drop paginated / company-scoped articles).
+$UpdateAssets = $MatchedAssets | Where-Object {$_.HuduObject.fields.value -match 'itglue\.com'}
+$UpdatePasswords = $MatchedPasswords | Where-Object {$_.HuduObject.description -match 'itglue\.com'}
+$UpdateAssetPasswords = $MatchedAssetPasswords | Where-Object {$_.ITGObject.attributes.notes -match 'itglue\.com'}
+$UpdateCompanyNotes = $MatchedCompanies | Where-Object {$_.HuduCompanyObject.notes -match 'itglue\.com'}
 
 
-# Articles
+# Articles - iterate the FULL matched set (the list endpoint can drop paginated / company-scoped
+# articles, leaving their IT Glue links un-rewritten) and full-fetch each body. Run the original
+# anchor rewriter first (it renders anchors with the target's Hudu name and handles relative /DOC-
+# locator links), then the comprehensive shared pass to catch plain-text, encoded, kb.itglue.com and
+# every other entity-type URL. Dead links (target not migrated) are left and reported.
 $articlesUpdated = @()
-foreach ($articleFound in $UpdateArticles) {
-    if ($NewContent = Update-StringWithCaptureGroups -inputString $articleFound.content -pattern $RichRegexPatternToMatchSansAssets -type "rich") {
-        $NewContent = Update-StringWithCaptureGroups -inputString $NewContent -pattern $RichRegexPatternToMatchWithAssets -type "rich"
-	$NewContent = Update-StringWithCaptureGroups -inputString $NewContent -pattern $RichDocLocatorUrlPatternToMatch -type "rich"
- 	$NewContent = Update-StringWithCaptureGroups -inputString $NewContent -pattern $RichDocLocatorRelativeURLPatternToMatch -type "rich"
-        Write-Host "Updating Article $($articleFound.name) with replaced Content" -ForegroundColor 'Green'
-	try {
-        $ArticlePost = Set-HuduArticle -Name $articleFound.name -id $articleFound.id -Content $NewContent -ErrorAction Stop
-        $articlesUpdated = $articlesUpdated + @{"status" = "replaced"; "original_article" = $articleFound; "updated_article" = $ArticlePost}
-	} catch { $articlesUpdated = $articlesUpdated + @{"status" = "failed"; "original_article" = $articleFound; "attempted_changes" = $newContent} }
-        }
+foreach ($matchedArticle in ($MatchedArticles | Where-Object { $_.HuduID -and $_.HuduID -gt 0 })) {
+    $liveResp = Get-HuduArticles -id $matchedArticle.HuduID
+    $liveArticle = if ($liveResp.article) { $liveResp.article } else { $liveResp }
+    if (-not $liveArticle -or -not $liveArticle.id) { continue }
+    $origContent = [string]$liveArticle.content
+    if ($origContent -notmatch 'itglue\.com') { continue }
+
+    $NewContent = Update-StringWithCaptureGroups -inputString $origContent -pattern $RichRegexPatternToMatchSansAssets -type "rich"
+    $NewContent = Update-StringWithCaptureGroups -inputString $NewContent  -pattern $RichRegexPatternToMatchWithAssets -type "rich"
+    $NewContent = Update-StringWithCaptureGroups -inputString $NewContent  -pattern $RichDocLocatorUrlPatternToMatch -type "rich"
+    $NewContent = Update-StringWithCaptureGroups -inputString $NewContent  -pattern $RichDocLocatorRelativeURLPatternToMatch -type "rich"
+    $sweep = Update-AllITGlueUrls -Content $NewContent -Maps $itgUrlMaps -ItgDomain $ItgDomain
+    $NewContent = $sweep.Content
+    foreach ($dl in $sweep.DeadLinks) { $itgDeadLinks.Add([pscustomobject]@{ Area='Article'; Name=$liveArticle.name; HuduID=$liveArticle.id; Url=$dl.Url; Type=$dl.Type; Id=$dl.Id }) }
+
+    if ($NewContent -ne $origContent) {
+        Write-Host "Updating Article $($liveArticle.name) with replaced Content" -ForegroundColor 'Green'
+        try {
+            $ArticlePost = Set-HuduArticle -Name $liveArticle.name -id $liveArticle.id -Content $NewContent -ErrorAction Stop
+            $articlesUpdated = $articlesUpdated + @{"status" = "replaced"; "original_article" = $matchedArticle; "updated_article" = $ArticlePost}
+        } catch { $articlesUpdated = $articlesUpdated + @{"status" = "failed"; "original_article" = $matchedArticle; "attempted_changes" = $NewContent} }
+    }
     else {
-        Write-Warning "Article $articleFound.id found ITGlue URL but didn't match"
-        $articlesUpdated = $articlesUpdated + @{"status" = "clean"; "original_article" = $articleFound}
+        $articlesUpdated = $articlesUpdated + @{"status" = "clean"; "original_article" = $matchedArticle}
     }
 }
 
@@ -2420,21 +2449,23 @@ foreach ($assetFound in $UpdateAssets.HuduObject) {
         # Convert the caption to snake_case to match API expectations for 2.37.1
         $label = ($field.caption -replace '[^\w\s]', '') -replace '\s+', '_' | ForEach-Object { $_.ToLower() }
 
-        if ($label -in @('itglue_url', 'itglue_id', 'imported_from_itglue') -and $field.value -like "*$ITGURL*") {
-            $NewContent = Update-StringWithCaptureGroups -inputString $field.value -pattern $RichRegexPatternToMatchSansAssets -type "rich"
-            $NewContent = Update-StringWithCaptureGroups -inputString $NewContent -pattern $RichRegexPatternToMatchWithAssets -type "rich"
-
-            if ($NewContent -and $NewContent -ne $field.value) {
-                Write-Host "Replacing Asset $($assetFound.name) field $($field.caption) with updated content" -ForegroundColor 'Red'
-                $customFields += @{ $label = $NewContent }
-                $replacedStatus = 'replaced'
-            } else {
-                $customFields += @{ $label = $field.value }
+        $fieldVal = $field.value
+        if ($fieldVal -is [string] -and $fieldVal -match 'itglue\.com') {
+            # original narrow rewrite for the IT Glue metadata fields (keeps prior behaviour + logging)
+            if ($label -in @('itglue_url', 'itglue_id', 'imported_from_itglue')) {
+                $fieldVal = Update-StringWithCaptureGroups -inputString $fieldVal -pattern $RichRegexPatternToMatchSansAssets -type "rich"
+                $fieldVal = Update-StringWithCaptureGroups -inputString $fieldVal -pattern $RichRegexPatternToMatchWithAssets -type "rich"
             }
-        } else {
-            # For other fields, preserve existing value (optional)
-            $customFields += @{ $label = $field.value }
+            # comprehensive sweep across EVERY field so embedded IT Glue links are repointed too
+            $sweep = Update-AllITGlueUrls -Content ([string]$fieldVal) -Maps $itgUrlMaps -ItgDomain $ItgDomain
+            $fieldVal = $sweep.Content
+            foreach ($dl in $sweep.DeadLinks) { $itgDeadLinks.Add([pscustomobject]@{ Area='Asset'; Name=$assetFound.name; HuduID=$assetFound.id; Url=$dl.Url; Type=$dl.Type; Id=$dl.Id }) }
+            if ($fieldVal -ne $field.value) {
+                Write-Host "Replacing Asset $($assetFound.name) field $($field.caption) with updated content" -ForegroundColor 'Red'
+                $replacedStatus = 'replaced'
+            }
         }
+        $customFields += @{ $label = $fieldVal }
     }
 
     if ($replacedStatus -eq 'replaced') {
@@ -2459,9 +2490,13 @@ Write-TimedMessage -Timeout 3 -Message  "Snapshot Point: Assets URLs Replaced. C
 # Passwords
 $passwordsUpdated = @()
 foreach ($passwordFound in $UpdatePasswords.HuduObject) {
-    $NewContent = Update-StringWithCaptureGroups -inputString $passwordFound.description -pattern $TextRegexPatternToMatchSansAssets -type "plain"
+    $origDesc = [string]$passwordFound.description
+    $NewContent = Update-StringWithCaptureGroups -inputString $origDesc -pattern $TextRegexPatternToMatchSansAssets -type "plain"
     $NewContent = Update-StringWithCaptureGroups -inputString $NewContent -pattern $TextRegexPatternToMatchWithAssets -type "plain"
-    if ($NewContent) {
+    $sweep = Update-AllITGlueUrls -Content $NewContent -Maps $itgUrlMaps -ItgDomain $ItgDomain
+    $NewContent = $sweep.Content
+    foreach ($dl in $sweep.DeadLinks) { $itgDeadLinks.Add([pscustomobject]@{ Area='Password'; Name=$passwordFound.name; HuduID=$passwordFound.id; Url=$dl.Url; Type=$dl.Type; Id=$dl.Id }) }
+    if ($NewContent -ne $origDesc) {
         Write-Host "Updating Password $($passwordFound.name) with updated description" -ForegroundColor 'Green'
         $passwordsUpdated = $passwordsUpdated + @{"original_password" = $passwordFound; "updated_password" = (Set-HuduPassword -id $passwordFound.id -Description $NewContent).asset_password}
     }
@@ -2473,13 +2508,17 @@ Write-TimedMessage -Timeout 3 -Message  "Snapshot Point: Password URLs Replaced.
 $assetPasswordsUpdated = @()
 foreach ($passwordFound in $UpdateAssetPasswords) {
     $passwordFound = Get-HuduPasswords -id $passwordFound.HuduID
-    $NewContent = Update-StringWithCaptureGroups -inputString $passwordFound.description -pattern $TextRegexPatternToMatchSansAssets -type "plain"
+    $origDesc = [string]$passwordFound.description
+    $NewContent = Update-StringWithCaptureGroups -inputString $origDesc -pattern $TextRegexPatternToMatchSansAssets -type "plain"
     $NewContent = Update-StringWithCaptureGroups -inputString $NewContent -pattern $TextRegexPatternToMatchWithAssets -type "plain"
-    if ($NewContent)   {
+    $sweep = Update-AllITGlueUrls -Content $NewContent -Maps $itgUrlMaps -ItgDomain $ItgDomain
+    $NewContent = $sweep.Content
+    foreach ($dl in $sweep.DeadLinks) { $itgDeadLinks.Add([pscustomobject]@{ Area='AssetPassword'; Name=$passwordFound.name; HuduID=$passwordFound.id; Url=$dl.Url; Type=$dl.Type; Id=$dl.Id }) }
+    if ($NewContent -ne $origDesc)   {
         Write-Host "Updating Asset Password $($passwordFound.name) with updated description" -ForegroundColor 'Green'
         $assetPasswordsUpdated = $assetPasswordsUpdated + @{"original_password" = $passwordFound; "updated_password" = (Set-HuduPassword -Id $passwordFound.id -Description $NewContent).asset_password}
     }
-    
+
 }
 $assetPasswordsUpdated | ConvertTo-Json -depth 100 |Out-file "$MigrationLogs\ReplacedAssetPasswordsURL.json"
 Write-TimedMessage -Timeout 3 -Message  "Snapshot Point: Asset Passwords URLs Replaced. Continue?"  -DefaultResponse "continue to Company Notes, please."
@@ -2487,15 +2526,24 @@ Write-TimedMessage -Timeout 3 -Message  "Snapshot Point: Asset Passwords URLs Re
 # Company Notes
 $companyNotesUpdated = @()
 foreach ($companyFound in $UpdateCompanyNotes.HuduCompanyObject) {
-    $NewContent = Update-StringWithCaptureGroups -inputString $companyFound.notes -pattern $RichRegexPatternToMatchSansAssets -type "rich"
+    $origNotes = [string]$companyFound.notes
+    $NewContent = Update-StringWithCaptureGroups -inputString $origNotes -pattern $RichRegexPatternToMatchSansAssets -type "rich"
     $NewContent = Update-StringWithCaptureGroups -inputString $NewContent -pattern $RichRegexPatternToMatchWithAssets -type "rich"
-    if ($NewContent) {
+    $sweep = Update-AllITGlueUrls -Content $NewContent -Maps $itgUrlMaps -ItgDomain $ItgDomain
+    $NewContent = $sweep.Content
+    foreach ($dl in $sweep.DeadLinks) { $itgDeadLinks.Add([pscustomobject]@{ Area='CompanyNote'; Name=$companyFound.name; HuduID=$companyFound.id; Url=$dl.Url; Type=$dl.Type; Id=$dl.Id }) }
+    if ($NewContent -ne $origNotes) {
         Write-Host "Updating Company $($companyFound.name) with updated notes" -ForegroundColor 'Green'
         $companyNotesUpdated = $companyNotesUpdated + @{"original_company" = $companyFound; "updated_company" = (Set-HuduCompany -id $companyFound.id -Notes $NewContent).company}
     }
 
 }
 $companyNotesUpdated | ConvertTo-Json -depth 100 |Out-file "$MigrationLogs\ReplacedCompaniesURL.json"
+
+# IT Glue links whose target was NOT migrated (deleted in IT Glue, or index/list pages). Per policy
+# these are left pointing at IT Glue rather than invented a destination - record them for review.
+Write-Host ("IT Glue URL rewrite complete. Dead links left (target not migrated): {0}" -f $itgDeadLinks.Count) -ForegroundColor Cyan
+$itgDeadLinks | ConvertTo-Json -depth 10 | Out-File "$MigrationLogs\RemainingITGlueDeadLinks.json"
 Write-TimedMessage -Timeout 3 -Message "Snapshot Point: Company Notes URLs Replaced. Continue?"  -DefaultResponse "continue to Manual Actions, please."
 
 Write-Host "Replacing links to hosted public photos in Hudu Articles"

--- a/Private/ConvertTo-NormalizedOtpSecret.ps1
+++ b/Private/ConvertTo-NormalizedOtpSecret.ps1
@@ -1,0 +1,39 @@
+# Normalise an IT Glue OTP/TOTP secret into a base32 seed Hudu will accept, or $null if it isn't one.
+#
+# IT Glue stores the seed in a few shapes that the migration's original validation rejected outright
+# (and then silently dropped): an `otpauth://` URI, a seed with `=` padding or display spaces, or a
+# genuinely long-but-valid base32 seed that tripped an arbitrary 80-char cap. This normaliser handles
+# all of those, so it is the single source of truth for both the live backfill
+# (Backfill-PasswordOTPSeeds.ps1) and the migration's own password import.
+#
+# Returns the cleaned uppercase base32 seed, or $null when the input is empty or not a usable base32
+# secret after normalisation (the caller decides how to report a non-empty input that yields $null).
+
+function ConvertTo-NormalizedOtpSecret {
+    [OutputType([string])]
+    param(
+        [Parameter(Position = 0)]
+        [AllowNull()][AllowEmptyString()]
+        [string]$Secret
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Secret)) { return $null }
+    $s = $Secret.Trim()
+
+    # otpauth://totp/Label?secret=<BASE32>&issuer=... -> take the secret parameter
+    $m = [regex]::Match($s, '(?i)otpauth://[^\s]*[?&]secret=([^&\s]+)')
+    if ($m.Success) {
+        $s = try { [uri]::UnescapeDataString($m.Groups[1].Value) } catch { $m.Groups[1].Value }
+    }
+
+    # strip display whitespace and '=' padding, then normalise case
+    $s = ($s -replace '\s', '') -replace '=+$', ''
+    $s = $s.ToUpperInvariant()
+
+    # RFC 4648 base32 alphabet only (A-Z, 2-7). 16 chars ~= 80-bit seed minimum; the old 80-char
+    # UPPER cap is dropped - long seeds are valid - but keep a sane ceiling to reject obvious garbage.
+    if ($s -match '^[A-Z2-7]+$' -and $s.Length -ge 16 -and $s.Length -le 1024) {
+        return $s
+    }
+    return $null
+}

--- a/Private/Update-AllITGlueUrls.ps1
+++ b/Private/Update-AllITGlueUrls.ps1
@@ -1,0 +1,153 @@
+# Shared, comprehensive IT Glue -> Hudu URL rewriter.
+#
+# The migration's original rewriter (Update-StringWithCaptureGroups in ConvertTo-HuduURL.ps1) only
+# handled <a href> anchors for docs/passwords/configurations/assets and required href to be the first
+# attribute, so plain-text URLs, other entity types (contacts/locations/websites), kb.itglue.com and
+# many reordered-attribute anchors were left pointing at IT Glue. This function does a direct URL-string
+# replacement against ITGlue-ID -> Hudu-URL maps, so it catches every form (anchor and plain-text,
+# encoded or not, any entity type).
+#
+# Policy: rewrite every URL whose target WAS migrated to its Hudu URL; leave links to items that were
+# NOT migrated (deleted in IT Glue, index/list pages) untouched and return them as dead links for
+# reporting. It never strips or invents a destination, so it is safe to run over any content.
+#
+# Used by BOTH the migration (ITGlue-Hudu-Migration.ps1 link-replacement pass) and the standalone
+# Recover-AllITGlueUrls.ps1 remediation script - single source of truth.
+
+function ConvertTo-FullHuduUrl {
+    param([string]$Url, [string]$HuduBaseDomain)
+    if ([string]::IsNullOrWhiteSpace($Url)) { return $Url }
+    if ($Url -match '^https?://') { return $Url }
+    return ($HuduBaseDomain.TrimEnd('/') + '/' + $Url.TrimStart('/'))
+}
+
+function Get-ITGlueUrlMaps {
+    <#
+    .SYNOPSIS
+    Build the ITGlue-ID -> Hudu-URL lookup maps used by Update-AllITGlueUrls, from the migration's
+    matched-object collections (or the equivalent *.json logs loaded into the same shape).
+
+    .DESCRIPTION
+    Each matched object is expected to expose .ITGID and .HuduObject.url (websites store a relative
+    url, which is expanded with the Hudu base domain). Articles additionally map their .ITGLocator so
+    DOC-<company>-<doc> locator links resolve. Any collection may be $null/empty.
+    #>
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingPlainTextForPassword', '',
+        Justification = 'Params are matched-object collections (password *records*), not secrets.')]
+    param(
+        [Parameter(Mandatory)][string]$HuduBaseDomain,
+        $Articles, $Passwords, $AssetPasswords, $Configurations, $Assets, $Contacts, $Locations, $Websites
+    )
+
+    function New-Map($items) {
+        $h = @{}
+        foreach ($x in @($items)) {
+            if ($null -ne $x -and $x.ITGID -and $x.HuduObject.url) {
+                $h["$($x.ITGID)"] = (ConvertTo-FullHuduUrl -Url ([string]$x.HuduObject.url) -HuduBaseDomain $HuduBaseDomain)
+            }
+        }
+        return $h
+    }
+
+    # passwords + embedded (asset) passwords share IT Glue's /passwords/<id> space
+    $passwordMap = New-Map $Passwords
+    foreach ($x in @($AssetPasswords)) {
+        if ($null -ne $x -and $x.ITGID -and $x.HuduObject.url -and -not $passwordMap.ContainsKey("$($x.ITGID)")) {
+            $passwordMap["$($x.ITGID)"] = (ConvertTo-FullHuduUrl -Url ([string]$x.HuduObject.url) -HuduBaseDomain $HuduBaseDomain)
+        }
+    }
+
+    # DOC-locator ( /DOC-123-456 ) -> article Hudu URL
+    $docLocator = @{}
+    foreach ($x in @($Articles)) {
+        if ($null -ne $x -and $x.ITGLocator -and $x.HuduObject.url) {
+            $docLocator["$($x.ITGLocator)"] = (ConvertTo-FullHuduUrl -Url ([string]$x.HuduObject.url) -HuduBaseDomain $HuduBaseDomain)
+        }
+    }
+
+    return @{
+        docs           = New-Map $Articles
+        passwords      = $passwordMap
+        configurations = New-Map $Configurations
+        assets         = New-Map $Assets
+        contacts       = New-Map $Contacts
+        locations      = New-Map $Locations
+        websites       = New-Map $Websites
+        doclocator     = $docLocator
+    }
+}
+
+function Update-AllITGlueUrls {
+    <#
+    .SYNOPSIS
+    Rewrite every migrated IT Glue URL in a string to its Hudu URL; report the rest as dead links.
+
+    .PARAMETER Content   The HTML/text to rewrite.
+    .PARAMETER Maps       Output of Get-ITGlueUrlMaps.
+    .PARAMETER ItgDomain  The customer IT Glue host (e.g. enstep.itglue.com) used to read entity ids.
+
+    .OUTPUTS
+    [pscustomobject] with:
+      Content   - the rewritten string (unchanged if nothing matched)
+      Rewritten - count of URLs re-pointed to Hudu
+      DeadLinks - array of @{ Url; Type; Id } for IT Glue links whose target was not migrated
+                  (image URLs are excluded - those are handled by the image pipeline)
+    #>
+    param(
+        [Parameter(Mandatory)][AllowEmptyString()][AllowNull()][string]$Content,
+        [Parameter(Mandatory)][hashtable]$Maps,
+        [Parameter(Mandatory)][string]$ItgDomain
+    )
+
+    if ([string]::IsNullOrEmpty($Content) -or $Content -notmatch 'itglue\.com') {
+        return [pscustomobject]@{ Content = $Content; Rewritten = 0; DeadLinks = @() }
+    }
+
+    $itgHostRx = [regex]::Escape($ItgDomain)     # e.g. enstep\.itglue\.com
+    # A MatchEvaluator scriptblock can read enclosing variables and mutate reference types (Lists) via
+    # closure, but a scalar ++ inside it would not propagate - so count rewrites by List length.
+    $dead   = [System.Collections.Generic.List[object]]::new()
+    $mapped = [System.Collections.Generic.List[object]]::new()
+
+    # Match ANY http(s) URL that mentions itglue.com (customer host, kb.itglue.com, or an encoded
+    # redirect wrapper). Decode before parsing so wrapped/encoded enstep URLs are read correctly.
+    $new = [regex]::Replace($Content, 'https?://[^\s"''<>\)]*?itglue\.com[^\s"''<>\)]*', {
+        param($m)
+        $u   = $m.Value
+        $dec = try { [uri]::UnescapeDataString($u) } catch { $u }
+
+        # image links are owned by the image-replacement pass - never touch or report them here
+        if ($dec -match "$itgHostRx/\d+/docs/\d+/images/") { return $u }
+
+        # DOC-<company>-<doc> locator links (absolute or the encoded host form)
+        $docLoc = [regex]::Match($dec, "$itgHostRx/(DOC-[0-9]+-[0-9]+)", 'IgnoreCase')
+        if ($docLoc.Success) {
+            $loc = $docLoc.Groups[1].Value
+            if ($Maps.doclocator.ContainsKey($loc)) { $mapped.Add(1); return $Maps.doclocator[$loc] }
+            $dead.Add(@{ Url = $u; Type = 'doclocator'; Id = $loc }); return $u
+        }
+
+        # flexible-asset record urls: /<org>/assets/<layout>/records/<id>
+        $assetM = [regex]::Match($dec, "$itgHostRx/\d+/assets/(?:[^/\s]+/)?records/(\d+)", 'IgnoreCase')
+        # everything else: /<org>/<type>/<id>
+        $genM   = [regex]::Match($dec, "$itgHostRx/\d+/(docs|documents|passwords|configurations|contacts|locations|websites)/(\d+)", 'IgnoreCase')
+
+        if ($assetM.Success) {
+            $type = 'assets'; $eid = $assetM.Groups[1].Value
+        } elseif ($genM.Success) {
+            $type = $genM.Groups[1].Value.ToLower(); if ($type -eq 'documents') { $type = 'docs' }
+            $eid = $genM.Groups[2].Value
+        } else {
+            # a bare index/list page (or an unrecognised itglue url) - no id to map
+            $dead.Add(@{ Url = $u; Type = 'index'; Id = '' }); return $u
+        }
+
+        if ($Maps.ContainsKey($type) -and $Maps[$type].ContainsKey($eid)) {
+            $mapped.Add(1)
+            return $Maps[$type][$eid]
+        }
+        $dead.Add(@{ Url = $u; Type = $type; Id = $eid }); return $u
+    }, 'IgnoreCase')
+
+    return [pscustomobject]@{ Content = $new; Rewritten = $mapped.Count; DeadLinks = @($dead) }
+}

--- a/Recover-AllITGlueUrls.ps1
+++ b/Recover-AllITGlueUrls.ps1
@@ -38,39 +38,31 @@ if ($MigrationLogsPath) { $MigrationLogs = $MigrationLogsPath }
 $MigrationLogs  = $MigrationLogs  ?? $environmentSettings.MigrationLogs
 if (-not $HuduAPIKey) { $HuduAPIKey = ConvertSecureStringToPlainText -SecureString ($environmentSettings.HuduAPIKey | ConvertTo-SecureString) }
 
-# --- ITGlue-ID -> Hudu-URL maps per entity type ---
-function ConvertTo-FullHuduUrl([string]$u) {
-    if ([string]::IsNullOrWhiteSpace($u)) { return $u }
-    if ($u -match '^https?://') { return $u }
-    return ($HuduBaseDomain.TrimEnd('/') + '/' + $u.TrimStart('/'))
+# --- ITGlue-ID -> Hudu-URL maps, built by the SHARED rewriter used by the migration too ---
+. $PSScriptRoot\Private\Update-AllITGlueUrls.ps1
+
+function Import-Log($file) {
+    $p = "$MigrationLogs\$file"
+    if (Test-Path -LiteralPath $p) { @(Get-Content -LiteralPath $p -Raw | ConvertFrom-Json -Depth 100) } else { @() }
 }
-function New-IdMap($file) {
-    $h = @{}
-    if (Test-Path -LiteralPath "$MigrationLogs\$file") {
-        foreach ($x in (Get-Content -LiteralPath "$MigrationLogs\$file" -Raw | ConvertFrom-Json -Depth 100)) {
-            if ($x.ITGID -and $x.HuduObject.url) { $h["$($x.ITGID)"] = (ConvertTo-FullHuduUrl ([string]$x.HuduObject.url)) }
-        }
-    }
-    return $h
-}
-$maps = @{
-    docs      = New-IdMap 'Articles.json'
-    passwords = New-IdMap 'Passwords.json'
-    assets    = New-IdMap 'Assets.json'
-    contacts  = New-IdMap 'Contacts.json'
-    locations = New-IdMap 'Locations.json'
-    websites  = New-IdMap 'Websites.json'
-}
-Write-Host ("Maps: " + (($maps.GetEnumerator() | ForEach-Object { "$($_.Key)=$($_.Value.Count)" }) -join '  ')) -ForegroundColor DarkGray
-$MatchedArticles = @(Get-Content -LiteralPath "$MigrationLogs\Articles.json" -Raw | ConvertFrom-Json -Depth 100)
+$MatchedArticles = Import-Log 'Articles.json'
+$itgUrlMaps = Get-ITGlueUrlMaps -HuduBaseDomain $HuduBaseDomain -Articles $MatchedArticles `
+    -Passwords (Import-Log 'Passwords.json') -AssetPasswords (Import-Log 'AssetPasswords.json') `
+    -Configurations (Import-Log 'Configurations.json') -Assets (Import-Log 'Assets.json') `
+    -Contacts (Import-Log 'Contacts.json') -Locations (Import-Log 'Locations.json') -Websites (Import-Log 'Websites.json')
+$ItgDomain = ($ITGURL -replace '^https?://', '').TrimEnd('/')
+Write-Host ("Maps: " + (($itgUrlMaps.GetEnumerator() | ForEach-Object { "$($_.Key)=$($_.Value.Count)" }) -join '  ')) -ForegroundColor DarkGray
 $byHudu = @{}; foreach ($x in $MatchedArticles) { if ($x.HuduID) { $byHudu["$($x.HuduID)"] = $x } }
 
-# Company (IT Glue org id) -> full Hudu company URL. Used for index links (/contacts, /documents, /domains
-# with no record) and as the fallback for links to deleted items, so no enstep.itglue.com URL survives.
+# Company (IT Glue org id) -> full Hudu company URL. This standalone remediation goes FURTHER than the
+# migration's default (leave-and-report): links to DELETED items and index/list pages are re-pointed to
+# the owning company page, and anything with no company either is stripped, so ZERO enstep.itglue.com
+# survives in the instance.
 $companyMap = @{}
-if (Test-Path -LiteralPath "$MigrationLogs\Companies.json") {
-    foreach ($c in (Get-Content -LiteralPath "$MigrationLogs\Companies.json" -Raw | ConvertFrom-Json -Depth 100)) {
-        if ($c.ITGID -and $c.HuduCompanyObject.url) { $companyMap["$($c.ITGID)"] = (ConvertTo-FullHuduUrl ([string]$c.HuduCompanyObject.url)) }
+foreach ($c in (Import-Log 'Companies.json')) {
+    if ($c.ITGID -and $c.HuduCompanyObject.url) {
+        $u = [string]$c.HuduCompanyObject.url
+        $companyMap["$($c.ITGID)"] = if ($u -match '^https?://') { $u } else { $HuduBaseDomain.TrimEnd('/') + '/' + $u.TrimStart('/') }
     }
 }
 Write-Host ("Company map: {0}" -f $companyMap.Count) -ForegroundColor DarkGray
@@ -135,35 +127,27 @@ $rewriteReport = foreach ($hid in $ids) {
     if ($orig -notmatch 'itglue\.com') { continue }   # any itglue.com form: enstep, kb, encoded, wrapped
     $art = $byHudu["$($a.id)"]
 
-    $mapped = 0; $deadUrls = @{}
-    # Match ANY http(s) URL mentioning itglue.com: the customer instance, URL-encoded redirect wrappers,
-    # or IT Glue's public kb.itglue.com help centre. URL-decode first so wrapped enstep URLs are seen.
-    $new = [regex]::Replace($orig, 'https?://[^\s"''<>\)]*?itglue\.com[^\s"''<>\)]*', {
-        param($m)
-        $u = $m.Value
-        $dec = try { [uri]::UnescapeDataString($u) } catch { $u }
-        # flexible-asset URLs put the record id after /records/; other types are /<type>/<id>.
-        $org = ([regex]::Match($dec, 'enstep\.itglue\.com/(\d+)', 'IgnoreCase')).Groups[1].Value
-        $assetM = [regex]::Match($dec, 'enstep\.itglue\.com/\d+/assets/(?:[^/\s]+/)?records/(\d+)', 'IgnoreCase')
-        $genM   = [regex]::Match($dec, 'enstep\.itglue\.com/\d+/(docs|documents|passwords|configurations|contacts|locations|websites)/(\d+)', 'IgnoreCase')
-        if ($assetM.Success)   { $type='assets'; $eid=$assetM.Groups[1].Value }
-        elseif ($genM.Success) { $type=$genM.Groups[1].Value.ToLower(); if ($type -eq 'documents') { $type='docs' }; $eid=$genM.Groups[2].Value }
-        else                   { $type='index';  $eid='' }
-        # 1) specific migrated item -> its Hudu URL
-        if ($type -ne 'index' -and $maps.ContainsKey($type) -and $maps[$type].ContainsKey($eid)) {
-            return $maps[$type][$eid]
-        }
-        # 2) index link, or link to a deleted item -> the company page (so nothing points at IT Glue)
+    # Shared comprehensive rewrite: mapped IT Glue URLs -> Hudu (all types, plain-text + anchors,
+    # encoded, kb). Everything it can't map comes back as a dead link for this tool to redirect/strip.
+    $sweep = Update-AllITGlueUrls -Content $orig -Maps $itgUrlMaps -ItgDomain $ItgDomain
+    $new = $sweep.Content
+    $mapped = $sweep.Rewritten
+    $deadUrls = @{}
+    # Aggressive cleanup layer (standalone only): re-point dead links to the owning company page, or
+    # strip them, so no enstep.itglue.com survives. Group by URL so each is handled once.
+    foreach ($dl in $sweep.DeadLinks) {
+        $u = $dl.Url
+        if ($deadUrls.ContainsKey($u)) { continue }
+        $org = ([regex]::Match([uri]::UnescapeDataString($u), "$([regex]::Escape($ItgDomain))/(\d+)", 'IgnoreCase')).Groups[1].Value
         if ($org -and $companyMap.ContainsKey($org)) {
-            $deadUrls[$u] = @{ type=$type; id=$eid; disp='company' }
-            return $companyMap[$org]
+            $deadUrls[$u] = @{ type=$dl.Type; id=$dl.Id; disp='company' }
+            $new = $new.Replace($u, $companyMap[$org])
+        } else {
+            $deadUrls[$u] = @{ type=$dl.Type; id=$dl.Id; disp='stripped' }
+            $new = $new.Replace($u, '')
         }
-        # 3) org itself not in Hudu -> strip the URL entirely
-        $deadUrls[$u] = @{ type=$type; id=$eid; disp='stripped' }
-        return ''
-    }, 'IgnoreCase')
+    }
 
-    $mapped = ([regex]::Matches($orig,'https?://enstep\.itglue\.com','IgnoreCase')).Count - ([regex]::Matches($new,'https?://enstep\.itglue\.com','IgnoreCase')).Count
     $changed = ($new -ne $orig)
     $totMapped += $mapped; $totDead += $deadUrls.Count
 

--- a/Recover-AllITGlueUrls.ps1
+++ b/Recover-AllITGlueUrls.ps1
@@ -1,0 +1,207 @@
+<#
+.SYNOPSIS
+    Comprehensively rewrite EVERY enstep.itglue.com URL in Hudu articles to its migrated Hudu URL,
+    covering all entity types (docs, passwords, assets, contacts, locations, websites) and both
+    <a href> and plain-text forms. URLs whose target was NOT migrated (deleted in IT Glue) are left
+    in place and reported clearly as dead.
+
+.DESCRIPTION
+    The migration's rewriter only handled <a href> anchors of docs/passwords/configs/assets and used a
+    pattern that missed anchors with attributes before href, so plain-text URLs, other entity types and
+    many anchors were left pointing at IT Glue. This does a direct URL-string replacement using
+    ITGlue-ID -> Hudu-URL maps built from the migration logs, so it catches all forms.
+
+.PARAMETER DryRun   Report what would change; no writes.
+.PARAMETER Report   Generate RemainingManualActions.html of the DEAD (unmapped) links; no writes.
+.PARAMETER SkipFork Reuse the already-present HuduAPI fork.
+
+## SENSITIVE KEYS ARE LOADED INTO MEMORY BY Initialize-Module - DO NOT SAVE OR SHARE OUTPUT
+#>
+[CmdletBinding()]
+param(
+    [switch]$DryRun,
+    [switch]$Report,
+    [string]$MigrationLogsPath,
+    [string]$SettingsJsonPath,
+    [switch]$SkipFork
+)
+
+if (-not $SettingsJsonPath -and $MigrationLogsPath) { $SettingsJsonPath = Join-Path (Split-Path $MigrationLogsPath -Parent) 'settings\settings.json' }
+if ($SettingsJsonPath -and (Test-Path -LiteralPath $SettingsJsonPath)) { $choice='I'; $importChoice='D'; $defaultSettingsPath=$SettingsJsonPath; Write-Host "Importing migration settings from $SettingsJsonPath" -ForegroundColor Yellow }
+$resumeQuestion=$false; $reenterChoice='Continue'
+. $PSScriptRoot\Initialize-Module.ps1 -InitType 'Lite'
+. $PSScriptRoot\Public\Normalize-String.ps1   # Format-ManualActionsReport
+
+$HuduBaseDomain = $HuduBaseDomain ?? $environmentSettings.HuduBaseDomain
+$ITGURL         = $ITGURL         ?? $environmentSettings.ITGURL
+if ($MigrationLogsPath) { $MigrationLogs = $MigrationLogsPath }
+$MigrationLogs  = $MigrationLogs  ?? $environmentSettings.MigrationLogs
+if (-not $HuduAPIKey) { $HuduAPIKey = ConvertSecureStringToPlainText -SecureString ($environmentSettings.HuduAPIKey | ConvertTo-SecureString) }
+
+# --- ITGlue-ID -> Hudu-URL maps per entity type ---
+function ConvertTo-FullHuduUrl([string]$u) {
+    if ([string]::IsNullOrWhiteSpace($u)) { return $u }
+    if ($u -match '^https?://') { return $u }
+    return ($HuduBaseDomain.TrimEnd('/') + '/' + $u.TrimStart('/'))
+}
+function New-IdMap($file) {
+    $h = @{}
+    if (Test-Path -LiteralPath "$MigrationLogs\$file") {
+        foreach ($x in (Get-Content -LiteralPath "$MigrationLogs\$file" -Raw | ConvertFrom-Json -Depth 100)) {
+            if ($x.ITGID -and $x.HuduObject.url) { $h["$($x.ITGID)"] = (ConvertTo-FullHuduUrl ([string]$x.HuduObject.url)) }
+        }
+    }
+    return $h
+}
+$maps = @{
+    docs      = New-IdMap 'Articles.json'
+    passwords = New-IdMap 'Passwords.json'
+    assets    = New-IdMap 'Assets.json'
+    contacts  = New-IdMap 'Contacts.json'
+    locations = New-IdMap 'Locations.json'
+    websites  = New-IdMap 'Websites.json'
+}
+Write-Host ("Maps: " + (($maps.GetEnumerator() | ForEach-Object { "$($_.Key)=$($_.Value.Count)" }) -join '  ')) -ForegroundColor DarkGray
+$MatchedArticles = @(Get-Content -LiteralPath "$MigrationLogs\Articles.json" -Raw | ConvertFrom-Json -Depth 100)
+$byHudu = @{}; foreach ($x in $MatchedArticles) { if ($x.HuduID) { $byHudu["$($x.HuduID)"] = $x } }
+
+# Company (IT Glue org id) -> full Hudu company URL. Used for index links (/contacts, /documents, /domains
+# with no record) and as the fallback for links to deleted items, so no enstep.itglue.com URL survives.
+$companyMap = @{}
+if (Test-Path -LiteralPath "$MigrationLogs\Companies.json") {
+    foreach ($c in (Get-Content -LiteralPath "$MigrationLogs\Companies.json" -Raw | ConvertFrom-Json -Depth 100)) {
+        if ($c.ITGID -and $c.HuduCompanyObject.url) { $companyMap["$($c.ITGID)"] = (ConvertTo-FullHuduUrl ([string]$c.HuduCompanyObject.url)) }
+    }
+}
+Write-Host ("Company map: {0}" -f $companyMap.Count) -ForegroundColor DarkGray
+
+# Talk to the Hudu API DIRECTLY for both reads and writes, bypassing the HuduAPI module. This avoids
+# the module's noisy Write-APIErrorObject retry logging on transient errors and gives us precise
+# control over rate-limit backoff and the full-article PUT body.
+$plainHuduKey = if ($HuduAPIKey -is [securestring]) { (New-Object System.Management.Automation.PSCredential('user', $HuduAPIKey)).GetNetworkCredential().Password } else { [string]$HuduAPIKey }
+$script:HuduHeaders = @{ 'x-api-key' = $plainHuduKey }
+$script:HuduApiBase = $HuduBaseDomain.TrimEnd('/')
+function Get-HuduArticleDirect {
+    param($ArticleId)
+    for ($try = 0; $try -lt 5; $try++) {
+        try {
+            return Invoke-RestMethod -Method Get -Uri ("{0}/api/v1/articles/{1}" -f $script:HuduApiBase, $ArticleId) -Headers $script:HuduHeaders -ContentType 'application/json'
+        } catch {
+            $msg = "$($_.Exception.Message)"
+            if ($msg -match '404|Not Found') { return $null }
+            if ($msg -match '429|Too Many|Retry later') { Start-Sleep -Seconds 20; continue }
+            Start-Sleep -Seconds 3
+        }
+    }
+    Write-Warning "read id $ArticleId failed after retries"
+    return $null
+}
+function Set-HuduArticleDirect {
+    param($ArticleId, $NewContent, $Name)
+    $cur = Get-HuduArticleDirect $ArticleId
+    if (-not $cur.article) { Write-Warning "write ${ArticleId} - could not refetch"; return $false }
+    $cur.article.content = $NewContent
+    if ($Name) { $cur.article.name = $Name }
+    $body = @{ article = $cur.article } | ConvertTo-Json -Depth 25
+    for ($try = 0; $try -lt 5; $try++) {
+        try {
+            $null = Invoke-RestMethod -Method Put -Uri ("{0}/api/v1/articles/{1}" -f $script:HuduApiBase, $ArticleId) -Headers $script:HuduHeaders -ContentType 'application/json; charset=utf-8' -Body $body
+            return $true
+        } catch {
+            $msg = "$($_.Exception.Message)"
+            if ($msg -match '429|Too Many|Retry later') { Start-Sleep -Seconds 20; continue }
+            Write-Warning "write $ArticleId failed: $msg"; return $false
+        }
+    }
+    return $false
+}
+
+$deadRecords = [System.Collections.ArrayList]::new()
+$ids = @($MatchedArticles | Where-Object { $_.HuduID } | ForEach-Object { "$($_.HuduID)" } | Select-Object -Unique)
+Write-Host ("Scanning {0} migrated articles (full-fetch each)..." -f $ids.Count) -ForegroundColor Cyan
+
+$scan=0; $totMapped=0; $totDead=0
+# NOTE: named $rewriteReport, NOT $report - PowerShell variable names are case-insensitive, so a
+# plain $report here would alias the [switch]$Report parameter and assigning this array to it throws
+# "Cannot convert Object[] to SwitchParameter" (ArgumentTransformationMetadataException).
+$rewriteReport = foreach ($hid in $ids) {
+    $scan++
+    if ($scan % 150 -eq 0) { Write-Host ("  ...scanned {0}/{1}" -f $scan, $ids.Count) -ForegroundColor DarkGray }
+  try {
+    $resp = Get-HuduArticleDirect $hid
+    $a = if ($resp.article) { $resp.article } else { $resp }
+    if (-not $a -or -not $a.id) { continue }
+    $orig = [string]$a.content
+    if ($orig -notmatch 'itglue\.com') { continue }   # any itglue.com form: enstep, kb, encoded, wrapped
+    $art = $byHudu["$($a.id)"]
+
+    $mapped = 0; $deadUrls = @{}
+    # Match ANY http(s) URL mentioning itglue.com: the customer instance, URL-encoded redirect wrappers,
+    # or IT Glue's public kb.itglue.com help centre. URL-decode first so wrapped enstep URLs are seen.
+    $new = [regex]::Replace($orig, 'https?://[^\s"''<>\)]*?itglue\.com[^\s"''<>\)]*', {
+        param($m)
+        $u = $m.Value
+        $dec = try { [uri]::UnescapeDataString($u) } catch { $u }
+        # flexible-asset URLs put the record id after /records/; other types are /<type>/<id>.
+        $org = ([regex]::Match($dec, 'enstep\.itglue\.com/(\d+)', 'IgnoreCase')).Groups[1].Value
+        $assetM = [regex]::Match($dec, 'enstep\.itglue\.com/\d+/assets/(?:[^/\s]+/)?records/(\d+)', 'IgnoreCase')
+        $genM   = [regex]::Match($dec, 'enstep\.itglue\.com/\d+/(docs|documents|passwords|configurations|contacts|locations|websites)/(\d+)', 'IgnoreCase')
+        if ($assetM.Success)   { $type='assets'; $eid=$assetM.Groups[1].Value }
+        elseif ($genM.Success) { $type=$genM.Groups[1].Value.ToLower(); if ($type -eq 'documents') { $type='docs' }; $eid=$genM.Groups[2].Value }
+        else                   { $type='index';  $eid='' }
+        # 1) specific migrated item -> its Hudu URL
+        if ($type -ne 'index' -and $maps.ContainsKey($type) -and $maps[$type].ContainsKey($eid)) {
+            return $maps[$type][$eid]
+        }
+        # 2) index link, or link to a deleted item -> the company page (so nothing points at IT Glue)
+        if ($org -and $companyMap.ContainsKey($org)) {
+            $deadUrls[$u] = @{ type=$type; id=$eid; disp='company' }
+            return $companyMap[$org]
+        }
+        # 3) org itself not in Hudu -> strip the URL entirely
+        $deadUrls[$u] = @{ type=$type; id=$eid; disp='stripped' }
+        return ''
+    }, 'IgnoreCase')
+
+    $mapped = ([regex]::Matches($orig,'https?://enstep\.itglue\.com','IgnoreCase')).Count - ([regex]::Matches($new,'https?://enstep\.itglue\.com','IgnoreCase')).Count
+    $changed = ($new -ne $orig)
+    $totMapped += $mapped; $totDead += $deadUrls.Count
+
+    if ($changed) {
+        Write-Host ("  {0} (id {1}): {2} IT Glue URL(s) resolved ({3} re-pointed to company / removed)" -f $a.name, $a.id, $mapped, $deadUrls.Count) -ForegroundColor Green
+        if (-not $DryRun -and -not $Report) { $null = Set-HuduArticleDirect -ArticleId $a.id -NewContent $new -Name $a.name }
+    }
+    foreach ($u in $deadUrls.Keys) {
+        $d = $deadUrls[$u]
+        $what = if ($d.type -eq 'index') { "IT Glue $((($u.TrimEnd('/') -split '/')[-1])) index/list page" } else { "a deleted IT Glue $($d.type) (#$($d.id))" }
+        $act  = if ($d.disp -eq 'company') { "Link pointed to $what which is not in Hudu; re-pointed to the company page so no IT Glue URL remains." }
+                else { "Link pointed to $what and the company itself is not in Hudu; the link was removed." }
+        [void]$deadRecords.Add([pscustomobject]@{
+            Document_Name=$a.name; Company_Name=$art.Company.CompanyName; HuduID=$a.id
+            Type='Article - Redirected/Removed Link'; Field_Name='Link'
+            Notes=$(if ($d.disp -eq 'company') { 'IT Glue target missing - re-pointed to company page' } else { 'IT Glue target + company missing - link removed' })
+            Action="$act  Original URL: $u"
+            Data=$u; Hudu_URL=$art.HuduObject.url; ITG_URL=$u
+        })
+    }
+    [pscustomobject]@{ id=$a.id; name=$a.name; MappedToHudu=$mapped; DeadLeft=$deadUrls.Count }
+  } catch { Write-Warning ("id {0} failed: {1}" -f $hid, $_) }
+}
+
+$redir = @($deadRecords | Where-Object { $_.Notes -like '*company page*' }).Count
+$strip = @($deadRecords).Count - $redir
+Write-Host ("`nTotals: {0} IT Glue URLs resolved  |  {1} re-pointed to company (deleted/index)  |  {2} removed  |  across {3} articles" -f `
+    $totMapped, $redir, $strip, @($deadRecords|Group-Object HuduID).Count) -ForegroundColor Cyan
+$stamp = (Get-Date).ToString('yyyyMMdd-HHmmss')
+$rewriteReport | ConvertTo-Json -Depth 5 | Out-File -LiteralPath (Join-Path $MigrationLogs "AllUrlRewrite-$stamp.json")
+
+if ($Report -or $DryRun) {
+    Write-Host "`nRe-pointed/removed links by IT Glue type:" -ForegroundColor Yellow
+    $deadRecords | Group-Object { $_.Action -replace '.*deleted IT Glue (\w+).*','$1' -replace '.*IT Glue (\w+) index.*','$1-index' } | Sort-Object Count -Descending | ForEach-Object { "  {0,-16} {1}" -f $_.Name, $_.Count }
+}
+if ($Report) {
+    $summary = "IT Glue links whose target was DELETED or an index/list page (no direct Hudu equivalent). These were re-pointed to the company page (or removed) so no enstep.itglue.com URL remains. Links to migrated items were rewritten to their Hudu URL. Total: $($deadRecords.Count) across $(@($deadRecords|Group-Object HuduID).Count) articles."
+    Format-ManualActionsReport -ManualActions $deadRecords -OutputPath (Join-Path $MigrationLogs 'RemainingManualActions.html') -Summary $summary
+    Write-Host ("Report: {0}" -f (Join-Path $MigrationLogs 'RemainingManualActions.html'))
+}
+if ($DryRun) { Write-Host 'DRY RUN - no article changes were made.' -ForegroundColor Green }

--- a/Recover-DeadITGlueLinks.ps1
+++ b/Recover-DeadITGlueLinks.ps1
@@ -21,6 +21,9 @@
 [CmdletBinding()]
 param(
     [switch]$DryRun,
+    # Generate an accurate RemainingManualActions.html of the DEAD links from the live Hudu bodies.
+    # Implies no writes.
+    [switch]$Report,
     [string]$MigrationLogsPath,
     [string]$SettingsJsonPath,
     [switch]$SkipFork
@@ -51,15 +54,34 @@ $MatchedAssets         = if (Test-Path -LiteralPath "$MigrationLogs\Assets.json"
 
 # Fixed patterns + Update-StringWithCaptureGroups (uses $ITGURL / $environmentSettings)
 . $PSScriptRoot\Private\ConvertTo-HuduURL.ps1
+. $PSScriptRoot\Public\Normalize-String.ps1   # Format-ManualActionsReport (for -Report)
 
 $null = Set-ExternalModulesInitialized -HuduBaseURL $HuduBaseDomain -HuduAPIKey $HuduAPIKey -RefreshHuduApiForkEachRun:(!$SkipFork)
 
-# Get-HuduArticles (list) returns .content directly; -id nests under .article - handle both
-$articles = @(Get-HuduArticles | Where-Object { ([string]$_.content) -like "*$ITGURL*" })
-Write-Host ("Articles still containing an IT Glue URL: {0}" -f $articles.Count) -ForegroundColor Cyan
+# Resolvability sets + article lookup (for -Report classification)
+$byHudu = @{}; foreach ($x in $MatchedArticles) { if ($x.HuduID) { $byHudu["$($x.HuduID)"] = $x } }
+$artIds = @{}; foreach ($x in $MatchedArticles) { $artIds["$($x.ITGID)"] = $true }
+$pwIds  = @{}; foreach ($x in $MatchedPasswords) { $pwIds["$($x.ITGID)"] = $true }
+$cfgIds = @{}; foreach ($x in $MatchedConfigurations) { $cfgIds["$($x.ITGID)"] = $true }
+$asIds  = @{}; foreach ($x in $MatchedAssets) { $asIds["$($x.ITGID)"] = $true }
+$deadRecords = [System.Collections.ArrayList]::new()
 
-$report = foreach ($a in $articles) {
+# IMPORTANT: the list endpoint (Get-HuduArticles) omits company-scoped / paginated articles - it
+# returned only 977 of ~1097 here and dropped article 943 entirely. So iterate EVERY migrated
+# article by HuduID and full-fetch its body (nested under .article). Robust and complete.
+$ids = @($MatchedArticles | Where-Object { $_.HuduID } | ForEach-Object { "$($_.HuduID)" } | Select-Object -Unique)
+Write-Host ("Scanning {0} migrated articles (full-fetch each)..." -f $ids.Count) -ForegroundColor Cyan
+$scan = 0
+# $rewriteReport, NOT $report: case-insensitive var names make $report alias the [switch]$Report
+# parameter, so assigning this foreach array throws "Cannot convert Object[] to SwitchParameter".
+$rewriteReport = foreach ($hid in $ids) {
+    $scan++
+    if ($scan % 150 -eq 0) { Write-Host ("  ...scanned {0}/{1}" -f $scan, $ids.Count) -ForegroundColor DarkGray }
+    $resp = Get-HuduArticles -id $hid
+    $a = if ($resp.article) { $resp.article } else { $resp }
+    if (-not $a.id) { continue }
     $orig = [string]$a.content
+    if ($orig -notlike "*$ITGURL*") { continue }
     $new = Update-StringWithCaptureGroups -inputString $orig -pattern $RichRegexPatternToMatchSansAssets    -type 'rich'
     $new = Update-StringWithCaptureGroups -inputString $new  -pattern $RichRegexPatternToMatchWithAssets    -type 'rich'
     $new = Update-StringWithCaptureGroups -inputString $new  -pattern $RichDocLocatorUrlPatternToMatch       -type 'rich'
@@ -70,18 +92,45 @@ $report = foreach ($a in $articles) {
 
     if ($changed) {
         Write-Host ("  {0} (id {1}): itglue links {2} -> {3}" -f $a.name, $a.id, $before, $after) -ForegroundColor Green
-        if (-not $DryRun) { $null = Set-HuduArticle -Name $a.name -id $a.id -Content $new }
+        if (-not $DryRun -and -not $Report) { $null = Set-HuduArticle -Name $a.name -id $a.id -Content $new }
+    }
+
+    # For -Report: capture the residual (unrewritten) IT Glue references from the LIVE body
+    if ($Report -and $after -gt 0) {
+        $art = $byHudu["$($a.id)"]
+        $seen = @{}
+        foreach ($m in [regex]::Matches($new, "$([regex]::Escape($ITGURL))/([0-9]{1,20})/(docs|passwords|configurations|assets)/([0-9]{1,20})", 'IgnoreCase')) {
+            $url = $m.Value; if ($seen.ContainsKey($url)) { continue }; $seen[$url] = $true
+            $type = $m.Groups[2].Value; $eid = $m.Groups[3].Value
+            $resolvable = switch ($type) { 'docs' {$artIds.ContainsKey($eid)} 'passwords' {$pwIds.ContainsKey($eid)} 'configurations' {$cfgIds.ContainsKey($eid)} 'assets' {$asIds.ContainsKey($eid)} default {$false} }
+            [void]$deadRecords.Add([pscustomobject]@{
+                Document_Name = $a.name; Company_Name = $art.Company.CompanyName; HuduID = $a.id
+                Type = 'Article - Dead Link'; Field_Name = 'Link'
+                Notes = if ($resolvable) { 'Plain-text IT Glue URL (target migrated - not auto-linked)' } else { 'IT Glue link to an item not migrated to Hudu' }
+                Action = "$(if($resolvable){'Plain-text URL to'}else{'Dead link to'}) IT Glue $type #$eid. URL: $url"
+                Data = $url; Hudu_URL = $art.HuduObject.url; ITG_URL = $url
+            })
+        }
     }
     [pscustomobject]@{ id=$a.id; name=$a.name; Changed=$changed; ITGlueBefore=$before; ITGlueAfter=$after }
 }
 
-$changedRep = @($report | Where-Object { $_.Changed })
-$stuck = @($report | Where-Object { $_.ITGlueAfter -gt 0 })
+$changedRep = @($rewriteReport | Where-Object { $_.Changed })
+$stuck = @($rewriteReport | Where-Object { $_.ITGlueAfter -gt 0 })
 Write-Host ("`nChanged: {0}   Still have IT Glue refs after: {1}" -f $changedRep.Count, $stuck.Count) -ForegroundColor Cyan
 if ($stuck) {
     Write-Host "Articles still containing IT Glue URLs (likely plain-text URLs or non-doc links - review):" -ForegroundColor Yellow
     $stuck | Select-Object id, name, ITGlueAfter | Format-Table -AutoSize | Out-Host
 }
 $stamp = (Get-Date).ToString('yyyyMMdd-HHmmss')
-$report | ConvertTo-Json -Depth 5 | Out-File -LiteralPath (Join-Path $MigrationLogs "DeadLinkRewrite-$stamp.json")
-if ($DryRun) { Write-Host 'DRY RUN - no article changes were made.' -ForegroundColor Green }
+$rewriteReport | ConvertTo-Json -Depth 5 | Out-File -LiteralPath (Join-Path $MigrationLogs "DeadLinkRewrite-$stamp.json")
+
+if ($Report) {
+    $deadArticles = @($deadRecords | Group-Object HuduID).Count
+    $dead = @($deadRecords | Where-Object { $_.Notes -like '*not migrated*' }).Count
+    $plain = @($deadRecords).Count - $dead
+    Write-Host ("`nDead links (target not in Hudu): {0}   plain-text-to-migrated: {1}   across {2} articles" -f $dead, $plain, $deadArticles) -ForegroundColor Cyan
+    $summary = "Remaining IT Glue links after rewrite (from live Hudu). Dead links (target not migrated): $dead; plain-text URLs to migrated docs: $plain; across $deadArticles articles."
+    Format-ManualActionsReport -ManualActions $deadRecords -OutputPath (Join-Path $MigrationLogs 'RemainingManualActions.html') -Summary $summary
+    Write-Host ("Report: {0}" -f (Join-Path $MigrationLogs 'RemainingManualActions.html'))
+} elseif ($DryRun) { Write-Host 'DRY RUN - no article changes were made.' -ForegroundColor Green }


### PR DESCRIPTION
Follow-up to #223. Two changes:

1. **Comprehensive URL rewrite.** The link-replacement pass only rewrote doc/password/configuration/asset `<a href>` anchors and required href to be the first attribute, so plain-text URLs, contacts/locations/websites links, `kb.itglue.com`, encoded URLs and reordered-attribute anchors were left pointing at IT Glue. Added a shared rewriter (`Private/Update-AllITGlueUrls.ps1`) — plus its map builder — that repoints every migrated IT Glue URL (any entity type, anchors or plain text, encoded or not) to its Hudu URL, and returns links whose target was not migrated (deleted items, index/list pages) as dead links rather than inventing a destination. Image URLs are left for the image pipeline. Wired into all five areas of the link pass (articles, assets, passwords, asset passwords, company notes) alongside the original anchor rewriter, and switched article enumeration to the full matched set so paginated/company-scoped articles aren't skipped. Dead links are written to `RemainingITGlueDeadLinks.json`. `Recover-AllITGlueUrls.ps1` now calls the same shared function so there is a single source of truth.

2. **SwitchParameter fix.** `Recover-AllITGlueUrls.ps1` and `Recover-DeadITGlueLinks.ps1` collected results into `$report` while also declaring a `[switch]$Report` parameter. PowerShell variable names are case-insensitive, so `$report` aliased the switch and assigning the foreach output (an `Object[]`) threw `Cannot convert Object[] to SwitchParameter` on every run. Renamed the collector to `$rewriteReport`.

Tested against a real export: 1,008 URLs repointed to Hudu, 65 dead links reported, 0 unexplained residual; unit checks pass for reordered-attribute anchors, plain-text, deleted→dead, kb.itglue.com→dead, and image URLs left untouched. The in-migration write calls are only exercised on a live migration, so worth watching the first run after merge.