### PR TITLE
Feat/skipemptyconfiglayouts

### DIFF
--- a/Add-HuduAttachmentsViaAPI.ps1
+++ b/Add-HuduAttachmentsViaAPI.ps1
@@ -28,6 +28,15 @@ if (-not ($FirstTimeLoad -eq 1)) {
 $AttachmentsPath = (Join-Path -Path $ITGlueExportPath -ChildPath "attachments")
 $AttachmentUrlMap = $AttachmentUrlMap ?? @{}
 $ITGlueAttachmentCache = @{}
+$MaxHuduUploadBytes = 100MB
+
+if (-not (Get-Variable -Name ManualActions -Scope Global -ErrorAction SilentlyContinue) -and -not (Get-Variable -Name ManualActions -Scope Script -ErrorAction SilentlyContinue)) {
+    if (Test-Path -LiteralPath "$MigrationLogs\ManualActions.json") {
+        $ManualActions = [System.Collections.ArrayList](Get-Content "$MigrationLogs\ManualActions.json" -Raw | ConvertFrom-Json -Depth 100)
+    } else {
+        $ManualActions = [System.Collections.ArrayList]@()
+    }
+}
 
 ###################### Initial Setup and Confirmations ###############################
 Write-Host "##################################################################" -ForegroundColor Yellow
@@ -271,6 +280,53 @@ function Save-AttachmentUrlMap {
     $script:AttachmentUrlMap | ConvertTo-Json -Depth 10 | Out-File "$MigrationLogs\AttachmentUrlMap.json"
 }
 
+function Format-FileSize {
+param(
+    [Int64]$Bytes
+)
+    if ($Bytes -ge 1GB) { return "$([Math]::Round($Bytes / 1GB, 2)) GB" }
+    if ($Bytes -ge 1MB) { return "$([Math]::Round($Bytes / 1MB, 2)) MB" }
+    if ($Bytes -ge 1KB) { return "$([Math]::Round($Bytes / 1KB, 2)) KB" }
+    return "$Bytes B"
+}
+
+function Add-OversizedAttachmentManualAction {
+param(
+    [System.IO.FileInfo]$FoundFile,
+    $FoundAsset,
+    [string]$UploadType,
+    [string]$FieldName = "Attachment"
+)
+    if ($null -eq $ManualActions) { return }
+
+    $fileSize = Format-FileSize -Bytes $FoundFile.Length
+    $limitSize = Format-FileSize -Bytes $MaxHuduUploadBytes
+    $itgUrl = (Get-OriginalAttachmentUrl -FoundFile $FoundFile -FoundAsset $FoundAsset) ??
+        $FoundAsset.ITGObject.attributes.'resource-url' ??
+        $FoundAsset.ITGObject.attributes.url
+
+    $manualLog = [PSCustomObject]@{
+        Document_Name = $FoundAsset.Name ?? $FoundAsset.name
+        Company_Name  = $FoundAsset.CompanyName ?? $FoundAsset.Company.CompanyName ?? $FoundAsset.ITGObject.attributes.'organization-name'
+        HuduID        = $FoundAsset.HuduID
+        Type          = "$UploadType - Attachment"
+        Field_Name    = $FieldName
+        Notes         = "Attachment exceeds Hudu upload size limit ($fileSize > $limitSize)"
+        Action        = "Manually upload or otherwise handle this attachment outside the migration."
+        Data          = "File: $($FoundFile.FullName); Size: $fileSize; Limit: $limitSize"
+        Hudu_URL      = $FoundAsset.HuduObject.url
+        ITG_URL       = $itgUrl
+    }
+
+    $null = $ManualActions.Add($manualLog)
+}
+
+function Save-ManualActionsLog {
+    if ($null -ne $ManualActions) {
+        $ManualActions | ConvertTo-Json -Depth 100 | Out-File "$MigrationLogs\ManualActions.json"
+    }
+}
+
 # Function for looping over found assets and attachments. Requires PSQL Connection
 function Add-HuduAttachment {
 param(
@@ -301,6 +357,22 @@ param(
                     Write-Host "Skipping $($FoundFile.name) because its already uploaded as an attachment" -ForegroundColor Yellow
                     continue
                 } #>
+                if ($FoundFile.Length -gt $MaxHuduUploadBytes) {
+                    $fileSize = Format-FileSize -Bytes $FoundFile.Length
+                    Write-Warning "Skipping $($FoundFile.name) because it is larger than 100 MB ($fileSize). Added to manual actions."
+                    Add-OversizedAttachmentManualAction -FoundFile $FoundFile -FoundAsset $FoundAsset -UploadType $UploadType
+                    [PSCustomObject]@{
+                        URL                    = $null
+                        OriginalAttachmentUrl  = Get-OriginalAttachmentUrl -FoundFile $FoundFile -FoundAsset $FoundAsset
+                        OriginalAttachmentUrls = @()
+                        ITGAttachmentID        = $null
+                        Uploadable_ID          = $FoundAsset.HuduID
+                        Uploadable_Type        = $UploadType
+                        FilePath               = $FoundFile.fullname
+                        status                 = "SKIPPED: Attachment is larger than 100 MB ($fileSize)"
+                    }
+                    continue
+                }
                 Write-Host "Pushing $($FoundFile.name) to Hudu $($UploadType) $($FoundAsset.name) - $($FoundAsset.HuduID)" -ForegroundColor Blue
                 try {
                     $HuduUpload = New-HuduUpload -FilePath $FoundFile.fullname -uploadable_id $FoundAsset.HuduID -uploadable_type $UploadType
@@ -454,6 +526,7 @@ if ($true -eq $UploadFieldsArePresent){
 $CSVMapPath = "$MigrationLogs\AttachmentFields-CSVMap.json"
 if (-not (Test-Path $CSVMapPath)) {
     Save-AttachmentUrlMap
+    Save-ManualActionsLog
     write-host "no optional CSV map found at $CSVMapPath. Attachments complete!"
     exit
 }
@@ -476,6 +549,16 @@ if ($CSVMapping) {
                     $FileToUpload = Get-Item -path (Join-Path -Path $ITGlueExportPath -ChildPath "$($n.foldername)\$($fr)")
                     $HuduAssetID = $ITGlueAssets |Where-Object {$_.itgid -eq $record.id}  |Select-Object -ExpandProperty HuduID
                     $HuduAssetName = $ITGlueAssets |Where-Object {$_.itgid -eq $record.id}  |Select-Object -ExpandProperty Name
+                    if ($FileToUpload.Length -gt $MaxHuduUploadBytes) {
+                        $fileSize = Format-FileSize -Bytes $FileToUpload.Length
+                        Write-Warning "Skipping CSV mapped attachment '$($FileToUpload.Name)' because it is larger than 100 MB ($fileSize). Added to manual actions."
+                        Add-OversizedAttachmentManualAction -FoundFile $FileToUpload -FoundAsset ([pscustomobject]@{
+                            Name       = $HuduAssetName
+                            HuduID     = $HuduAssetID
+                            HuduObject = [pscustomobject]@{ url = $null }
+                        }) -UploadType 'Asset' -FieldName $CSVHeader
+                        continue
+                    }
                     Write-Host "Uploading $($FileToUpload.fullname) to Hudu Asset $($HuduAssetName) - $($HuduAssetID)" -ForegroundColor Blue
                     $HuduUpload = New-HuduUpload -FilePath $FileToUpload.fullname -uploadable_id $HuduAssetID -uploadable_type 'Asset'
                     if ($fr -match '^https?://') {
@@ -501,5 +584,6 @@ if ($CSVMapping) {
     }
 }
 Save-AttachmentUrlMap
+Save-ManualActionsLog
 Write-Host "All attachments have been processed."
     

--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -4,6 +4,15 @@ if ($MyInvocation.InvocationName -eq '.') {
     Write-Host "Script was executed without dot-sourcing, this is the recommended method of running the script to ensure settings are retained in the session" -ForegroundColor Yellow; write-warning "exiting to prevent issues later on, please dot-source the script by running `. .\ITGlue-Hudu-Migration.ps1` from powershell 7 or using the provided ITGlue-Hudu-Migration.exe frontend.";
     exit 1
 }
+[version]$MinimumPSVersion = '7.5.1'
+[version]$MaximumPSVersion = '8.0'
+if (-not ($IsWindows -and [Environment]::OSVersion.Version -ge [version]'10.0.10240' -and [Runtime.InteropServices.RuntimeInformation]::OSArchitecture -in 'X86', 'X64' -and $PSVersionTable.PSEdition -eq 'Core' -and $PSVersionTable.PSVersion -ge $MinimumPSVersion -and $PSVersionTable.PSVersion -lt $MaximumPSVersion)) {
+    Write-Error "Unsupported environment. Requires Windows 10+, x86/x64, and PowerShell 7.5.1–7.x."
+    exit 1
+} else {
+    write-host "CPU arch $([Runtime.InteropServices.RuntimeInformation]::OSArchitecture) is good. Using windows $($iswindows). OS version is good $([Environment]::OSVersion.Version). PS edition is $($PSVersionTable.PSEdition) and $MinimumPSVersion <= $($PSVersionTable.PSVersion) < $MaximumPSVersion." -foregroundColor Green
+}
+try {Set-StrictMode -Off} catch {}
 
 if (-not (Get-Command -Name Get-EnsuredPath -ErrorAction SilentlyContinue)) { . $PSScriptRoot\Public\Init-OptionsAndLogs.ps1 }
 $ErroredItemsFolder = $(Get-EnsuredPath -path $(join-path $(Resolve-Path .).path "debug"))
@@ -13,13 +22,6 @@ $ErroredItemsFolder = $(Get-EnsuredPath -path $(join-path $(Resolve-Path .).path
 
 # Use this to set the context of the script runs
 $FirstTimeLoad = 1
-
-if ((get-host).version.major -ne 7) {
-    Write-Host "Powershell 7 Required" -foregroundcolor Red
-    exit 1
-}
-
-try {Set-StrictMode -Off} catch {}
 
 ############################### Functions ###############################
 # Import ImageMagick for Invoke-ImageTest Function (Disabled)

--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -5,12 +5,10 @@ if ($MyInvocation.InvocationName -eq '.') {
     exit 1
 }
 [version]$MinimumPSVersion = '7.5.1'
-[version]$MaximumPSVersion = '8.0'
-if (-not ($IsWindows -and [Environment]::OSVersion.Version -ge [version]'10.0.10240' -and [Runtime.InteropServices.RuntimeInformation]::OSArchitecture -in 'X86', 'X64' -and $PSVersionTable.PSEdition -eq 'Core' -and $PSVersionTable.PSVersion -ge $MinimumPSVersion -and $PSVersionTable.PSVersion -lt $MaximumPSVersion)) {
-    Write-Error "Unsupported environment. Requires Windows 10+, x86/x64, and PowerShell 7.5.1–7.x."
-    exit 1
+if (-not ($IsWindows -and [Environment]::OSVersion.Version -ge [version]'10.0.10240' -and [Runtime.InteropServices.RuntimeInformation]::OSArchitecture -in 'X86', 'X64' -and $PSVersionTable.PSEdition -eq 'Core' -and $PSVersionTable.PSVersion -ge $MinimumPSVersion)) {
+    Write-Error "Unsupported environment. Requires Windows 10+, x86/x64, and PowerShell 7.5.1–7.x."; exit 1;
 } else {
-    write-host "CPU arch $([Runtime.InteropServices.RuntimeInformation]::OSArchitecture) is good. Using windows $($iswindows). OS version is good $([Environment]::OSVersion.Version). PS edition is $($PSVersionTable.PSEdition) and $MinimumPSVersion <= $($PSVersionTable.PSVersion) < $MaximumPSVersion." -foregroundColor Green
+    write-host "CPU arch $([Runtime.InteropServices.RuntimeInformation]::OSArchitecture) is good. Using windows $($iswindows). OS version is good $([Environment]::OSVersion.Version). PS edition is $($PSVersionTable.PSEdition) (greater than required minimum of $MinimumPSVersion." -foregroundColor Green
 }
 try {Set-StrictMode -Off} catch {}
 

--- a/ITGlue-Hudu-Migration.ps1
+++ b/ITGlue-Hudu-Migration.ps1
@@ -983,7 +983,11 @@ if ($ResumeFound -eq $true -and (Test-Path "$MigrationLogs\Configurations.json")
 
             Write-Host "Processing $ConfigType"
 
-            $ParsedITGConfigs = $ITGConfigurations | Where-Object { $_.attributes."configuration-type-name" -eq $ConfigType }
+            $ParsedITGConfigs = @($ITGConfigurations | Where-Object { $_.attributes."configuration-type-name" -eq $ConfigType })
+            if ($ParsedITGConfigs.Count -eq 0) {
+                Write-Host "Skipping configuration layout '$($ConfigurationPrefix)$($ConfigType)' because it has no configurations in scope." -ForegroundColor Yellow
+                continue
+            }
 
             $ConfigMigrationName = "$($ConfigurationPrefix)$($ConfigType)"
             $ConfigImportAssetLayoutName = "$($ConfigurationPrefix)$($ConfigType)"

--- a/Initialize-Module.ps1
+++ b/Initialize-Module.ps1
@@ -32,12 +32,10 @@ if ($MyInvocation.InvocationName -eq '.') {
     exit 1
 }
 [version]$MinimumPSVersion = '7.5.1'
-[version]$MaximumPSVersion = '8.0'
-if (-not ($IsWindows -and [Environment]::OSVersion.Version -ge [version]'10.0.10240' -and [Runtime.InteropServices.RuntimeInformation]::OSArchitecture -in 'X86', 'X64' -and $PSVersionTable.PSEdition -eq 'Core' -and $PSVersionTable.PSVersion -ge $MinimumPSVersion -and $PSVersionTable.PSVersion -lt $MaximumPSVersion)) {
-    Write-Error "Unsupported environment. Requires Windows 10+, x86/x64, and PowerShell 7.5.1–7.x."
-    exit 1
+if (-not ($IsWindows -and [Environment]::OSVersion.Version -ge [version]'10.0.10240' -and [Runtime.InteropServices.RuntimeInformation]::OSArchitecture -in 'X86', 'X64' -and $PSVersionTable.PSEdition -eq 'Core' -and $PSVersionTable.PSVersion -ge $MinimumPSVersion)) {
+    Write-Error "Unsupported environment. Requires Windows 10+, x86/x64, and PowerShell 7.5.1–7.x."; exit 1;
 } else {
-    write-host "CPU arch $([Runtime.InteropServices.RuntimeInformation]::OSArchitecture) is good. Using windows $($iswindows). OS version is good $([Environment]::OSVersion.Version). PS edition is $($PSVersionTable.PSEdition) and $MinimumPSVersion <= $($PSVersionTable.PSVersion) < $MaximumPSVersion." -foregroundColor Green
+    write-host "CPU arch $([Runtime.InteropServices.RuntimeInformation]::OSArchitecture) is good. Using windows $($iswindows). OS version is good $([Environment]::OSVersion.Version). PS edition is $($PSVersionTable.PSEdition) (greater than required minimum of $MinimumPSVersion." -foregroundColor Green
 }
 ############################### Settings ###############################
 # Define the path to the settings.json file in the user's AppData folder

--- a/Initialize-Module.ps1
+++ b/Initialize-Module.ps1
@@ -25,15 +25,19 @@ param(
     [ValidateSet("Full", "Lite")]
     [string] $InitType
 )
-if ((get-host).version.major -ne 7) {
-    Write-Host "Powershell 7 Required" -foregroundcolor Red
-    exit 1
-}
 if ($MyInvocation.InvocationName -eq '.') {
     Write-Host "Script was dot-sourced" -ForegroundColor Green
 } else {
     Write-Host "Script was executed without dot-sourcing, this is the recommended method of running the script to ensure settings are retained in the session" -ForegroundColor Yellow; write-warning "exiting to prevent issues later on, please dot-source the script by running `. .\ITGlue-Hudu-Migration.ps1` from powershell 7 or using the provided ITGlue-Hudu-Migration.exe frontend.";
     exit 1
+}
+[version]$MinimumPSVersion = '7.5.1'
+[version]$MaximumPSVersion = '8.0'
+if (-not ($IsWindows -and [Environment]::OSVersion.Version -ge [version]'10.0.10240' -and [Runtime.InteropServices.RuntimeInformation]::OSArchitecture -in 'X86', 'X64' -and $PSVersionTable.PSEdition -eq 'Core' -and $PSVersionTable.PSVersion -ge $MinimumPSVersion -and $PSVersionTable.PSVersion -lt $MaximumPSVersion)) {
+    Write-Error "Unsupported environment. Requires Windows 10+, x86/x64, and PowerShell 7.5.1–7.x."
+    exit 1
+} else {
+    write-host "CPU arch $([Runtime.InteropServices.RuntimeInformation]::OSArchitecture) is good. Using windows $($iswindows). OS version is good $([Environment]::OSVersion.Version). PS edition is $($PSVersionTable.PSEdition) and $MinimumPSVersion <= $($PSVersionTable.PSVersion) < $MaximumPSVersion." -foregroundColor Green
 }
 ############################### Settings ###############################
 # Define the path to the settings.json file in the user's AppData folder

--- a/Public/Add-UploadFieldAttachments.ps1
+++ b/Public/Add-UploadFieldAttachments.ps1
@@ -201,6 +201,27 @@ foreach ($UploadAsset in $MatchedAssets | Where-Object { $_.HuduID -and $_.HuduI
         write-host "Matched '$filename' to '$($match.File.FullName)' with score $($match.Score) for asset ID $($UploadAsset.HuduID)"
 
         $matchedFile = $match.File
+        if ($matchedFile.Length -gt ($MaxHuduUploadBytes ?? 100MB)) {
+            $fileSize = if (Get-Command -Name Format-FileSize -ErrorAction SilentlyContinue) {
+                Format-FileSize -Bytes $matchedFile.Length
+            } else {
+                "$([Math]::Round($matchedFile.Length / 1MB, 2)) MB"
+            }
+            Write-Warning "Skipping upload field attachment '$filename' because it is larger than 100 MB ($fileSize). Added to manual actions."
+            if (Get-Command -Name Add-OversizedAttachmentManualAction -ErrorAction SilentlyContinue) {
+                Add-OversizedAttachmentManualAction -FoundFile $matchedFile -FoundAsset $UploadAsset -UploadType "Asset" -FieldName $name
+            }
+            $UnresolvedUploadFields["$($UploadAsset.HuduID):$name"] = @{
+                UploadAsset = $UploadAsset
+                FieldName   = $name
+                FilePath    = $matchedFile.FullName
+                ITGFileUrl  = $value.url
+                ITGFileName = $filename
+                MatchScore  = $match.Score
+                Problem     = "Attachment is larger than 100 MB"
+            }
+            continue
+        }
         $newUpload = $null; $newUpload = New-HuduUpload -uploadable_id $UploadAsset.HuduID -filePath $matchedFile.FullName -uploadable_type "Asset"; $newUpload = $newUpload.upload ?? $newUpload;
         if ($null -eq $newUpload) {
             Write-Warning "Failed to create upload for '$filename' at '$($matchedFile.FullName)' for asset ID $($UploadAsset.HuduID)"


### PR DESCRIPTION
Skipping empty config layouts in similar fashion to how we skip empty flexible asset layouts
more rigorous version check / arch / os check to start with.
uploads larger than 100mb go to the manual actions log
